### PR TITLE
Fix EZP-25490: Reimplement SystemInfo in ez-support-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+    - 5.5
+    - 5.6
+    - 7.0
+
+# test only master (+ Pull requests)
+branches:
+    only:
+        - master
+
+before_script:
+    - composer selfupdate
+    - composer install --prefer-dist
+
+script: phpunit --coverage-text
+
+notifications:
+    email: false

--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * File containing the SystemInfoDumpCommand class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SystemInfoDumpCommand extends ContainerAwareCommand
+{
+    /**
+     * Define command and input options.
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ez-support-tools:dump-info')
+            ->setDescription('Collects system information and dumps it.')
+            ->addArgument(
+                'info-collector',
+                InputArgument::REQUIRED,
+                'Which information collector should be used?'
+            )
+            ;
+    }
+
+    /**
+     * Execute the Command.
+     *
+     * @param $input InputInterface
+     * @param $output OutputInterface
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $infoCollector = $this->getContainer()->get($input->getArgument('info-collector'));
+        $infoValue = $infoCollector->build();
+
+        $outputArray = [];
+        // attributes() is deprecated, and getProperties() is protected. Smeg it, this is very temporary anyway.
+        foreach ($infoValue->attributes() as $property) {
+            $outputArray[$property] = $infoValue->$property;
+        }
+
+        $output->writeln(var_export($outputArray, true));
+    }
+}

--- a/EzSystemsEzSupportToolsBundle.php
+++ b/EzSystemsEzSupportToolsBundle.php
@@ -8,7 +8,6 @@
  */
 namespace EzSystems\EzSupportToolsBundle;
 
-use EzSystems\EzSupportToolsBundle\DependencyInjection\EzSystemsEzSupportToolsExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsEzSupportToolsBundle extends Bundle

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,3 +1,12 @@
 parameters:
+    support_tools.info_collectors.ezc_hardware.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
 
 services:
+    support_tools.info_collectors.ezc_hardware:
+        class: %support_tools.info_collectors.ezc_hardware.class%
+        arguments:
+            - @support_tools.info_collector.system_info.ezc_system_info
+
+    support_tools.info_collector.system_info.ezc_system_info:
+        class: ezcSystemInfo
+        factory: [EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory, buildEzcSystemInfo]

--- a/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * File containing the EzcHardwareSystemInfoCollector class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
+
+use Doctrine\DBAL\Connection;
+use ezcSystemInfo;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Value;
+
+/**
+ * Collects hardware system information using zetacomponents/sysinfo.
+ */
+class EzcHardwareSystemInfoCollector implements SystemInfoCollector
+{
+    /**
+     * ezcSystemInfo from eZ Components
+     *
+     * @var \ezcSystemInfo
+     */
+    private $ezcSystemInfo;
+
+    public function __construct(ezcSystemInfo $ezcSystemInfo)
+    {
+        $this->ezcSystemInfo = $ezcSystemInfo;
+    }
+
+    /**
+     * Builds information about the hardware eZ Platform is installed on.
+     *  - cpu information
+     *  - memory size
+     *
+     * @return Value\HardwareSystemInfo
+     */
+    public function build()
+    {
+        return new Value\HardwareSystemInfo([
+            'cpuType' => $this->ezcSystemInfo->cpuType,
+            'cpuSpeed' => $this->ezcSystemInfo->cpuSpeed,
+            'cpuCount' => $this->ezcSystemInfo->cpuCount,
+            'memorySize' => $this->ezcSystemInfo->memorySize,
+        ]);
+    }
+}

--- a/SystemInfo/Collector/SystemInfoCollector.php
+++ b/SystemInfo/Collector/SystemInfoCollector.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * File containing the SystemInfoCollector interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
+
+use EzSystems\EzSupportToolsBundle\SystemInfo\Value;
+
+/**
+ * Collects system information.
+ */
+interface SystemInfoCollector
+{
+    /**
+     * Builds system information.
+     *
+     * @return Value\SystemInfo
+     */
+    public function build();
+}

--- a/SystemInfo/EzcSystemInfoFactory.php
+++ b/SystemInfo/EzcSystemInfoFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * File containing the EzcSystemInfoFactory class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo;
+
+use ezcSystemInfo;
+
+/**
+ * Factory for zetacomponents/sysinfo. Used here to simplify testing.
+ */
+class EzcSystemInfoFactory
+{
+    public static function buildEzcSystemInfo()
+    {
+        return ezcSystemInfo::getInstance();
+    }
+}

--- a/SystemInfo/Value/HardwareSystemInfo.php
+++ b/SystemInfo/Value/HardwareSystemInfo.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * File containing the HardwareSystemInfo class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Value;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Value for information about the hardware we are running on.
+ */
+class HardwareSystemInfo extends ValueObject implements SystemInfo
+{
+    /**
+     * CPU type.
+     *
+     * @var string
+     */
+    public $cpuType;
+
+    /**
+     * CPU speed.
+     *
+     * @var string
+     */
+    public $cpuSpeed;
+
+    /**
+     * CPU count.
+     *
+     * @var int
+     */
+    public $cpuCount;
+
+    /**
+     * Memory size.
+     *
+     * @var float
+     */
+    public $memorySize;
+}

--- a/SystemInfo/Value/SystemInfo.php
+++ b/SystemInfo/Value/SystemInfo.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * File containing the SystemInfo interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Value;
+
+/**
+ * System information value.
+ */
+interface SystemInfo
+{
+}

--- a/Tests/SystemInfo/Collector/EzcHardwareTest.php
+++ b/Tests/SystemInfo/Collector/EzcHardwareTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * File containing the EzcHardwareTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector;
+
+use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Value\HardwareSystemInfo;
+use ezcSystemInfo;
+use PHPUnit_Framework_TestCase;
+
+class EzcHardwareTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ezcSystemInfo|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $ezcSystemInfoMock;
+
+    /**
+     * @var EzcHardwareSystemInfoCollector
+     */
+    private $ezcHardware;
+
+    public function setUp()
+    {
+        $this->ezcSystemInfoMock = $this->getMockBuilder('ezcSystemInfo')->disableOriginalConstructor()->getMock();
+        $this->ezcSystemInfoMock->cpuType = 'Intel(R) Core(TM) i7-3720QM CPU @ 2.60GHz';
+        $this->ezcSystemInfoMock->cpuSpeed = '2591.9000000000001';
+        $this->ezcSystemInfoMock->cpuCount = '1';
+        $this->ezcSystemInfoMock->memorySize = '1554632704';
+
+        $this->ezcHardware = new EzcHardwareSystemInfoCollector($this->ezcSystemInfoMock);
+    }
+
+    public function testBuild()
+    {
+        $value = $this->ezcHardware->build();
+
+        self::assertInstanceOf('EzSystems\EzSupportToolsBundle\SystemInfo\Value\HardwareSystemInfo', $value);
+
+        self::assertEquals(
+            new HardwareSystemInfo([
+                'cpuType' => $this->ezcSystemInfoMock->cpuType,
+                'cpuSpeed' => $this->ezcSystemInfoMock->cpuSpeed,
+                'cpuCount' => $this->ezcSystemInfoMock->cpuCount,
+                'memorySize' => $this->ezcSystemInfoMock->memorySize,
+            ]),
+            $value
+        );
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+// Skip autoloading if already done by phpunit alias (including from meta repo if this is vendor)
+if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+    return;
+}
+
+$autoloadFile = __DIR__ . '/../vendor/autoload.php';
+if (!file_exists($autoloadFile)) {
+    throw new RuntimeException('Install dependencies to run test suite.');
+}
+
+require_once $autoloadFile;

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,12 @@
         }
     ],
     "require": {
+        "ezsystems/ezpublish-kernel": "^6.2",
+        "zetacomponents/system-information": "^1.1"
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\EzSupportTools\\": ""
+            "EzSystems\\EzSupportToolsBundle\\": ""
         }
     },
     "extra": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,30 @@
+<?xml version = '1.0' encoding = 'UTF-8'?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="Tests/bootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        colors="false"
+        >
+
+    <testsuites>
+        <testsuite name="eZ Support Tools tests suite">
+            <directory suffix="Test.php">./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>Tests/</directory>
+                <directory>vendor/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25490
> Status: Ready for review

Implements the EzcHardware info collector only (split out from EzcSystem info for compartmentalisation reasons) to verify architecture and naming, and a simple, temporary Command:

```console
php app/console ez-support-tools:dump-info support_tools.info_collectors.ezc_hardware
array (
  'cpuType' => 'Intel(R) Core(TM) i7-3720QM CPU @ 2.60GHz',
  'cpuSpeed' => 2591.9000000000001,
  'cpuCount' => 1,
  'memorySize' => 1554632704,
)
```
- [x] Testing