### PR TITLE
Fix EZP-25567: eZSupportTools HardwareSystemInfoCollector minor fixes

### DIFF
--- a/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
@@ -8,7 +8,6 @@
  */
 namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
 
-use Doctrine\DBAL\Connection;
 use ezcSystemInfo;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value;
 

--- a/Tests/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * File containing the EzcHardwareTest class.
+ * File containing the EzcHardwareSystemInfoCollectorTest class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -13,7 +13,7 @@ use EzSystems\EzSupportToolsBundle\SystemInfo\Value\HardwareSystemInfo;
 use ezcSystemInfo;
 use PHPUnit_Framework_TestCase;
 
-class EzcHardwareTest extends PHPUnit_Framework_TestCase
+class EzcHardwareSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var ezcSystemInfo|\PHPUnit_Framework_MockObject_MockObject


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25567
> Status: Ready to review

- [x] Rename EzcHardwareTest to EzcHardwareSystemInfoCollectorTest
- [x] Remove irrelevant Doctrine Connection use statement