### PR TITLE
EZP-25579: SystemInfo view

### DIFF
--- a/Controller/SystemInfoController.php
+++ b/Controller/SystemInfoController.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\Controller;
+
+use EzSystems\EzSupportToolsBundle\View\SystemInfoView;
+
+/**
+ * Do we need that controller at all ?
+ */
+class SystemInfoController
+{
+    public function viewInfoAction(SystemInfoView $view)
+    {
+        return $view;
+    }
+}

--- a/DependencyInjection/Compiler/ViewBuilderPass.php
+++ b/DependencyInjection/Compiler/ViewBuilderPass.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ViewBuilderPass implements CompilerPassInterface
+{
+    /**
+     * Registers the SystemInfoViewBuilder into the view builder registry.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('ezpublish.view_builder.registry')) {
+            return;
+        }
+
+        $viewBuilderRegistry = $container->findDefinition('ezpublish.view_builder.registry');
+        $viewBuilders = [
+            $container->findDefinition('support_tools.view.system_info_view_builder'),
+        ];
+
+        $viewBuilderRegistry->addMethodCall('addToRegistry', [$viewBuilders]);
+    }
+}

--- a/EzSystemsEzSupportToolsBundle.php
+++ b/EzSystemsEzSupportToolsBundle.php
@@ -8,8 +8,15 @@
  */
 namespace EzSystems\EzSupportToolsBundle;
 
+use EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler\ViewBuilderPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsEzSupportToolsBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new ViewBuilderPass());
+    }
 }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,0 +1,3 @@
+ez_support_tools_system_info_view:
+    path: /ez-support-tools/view/{systemInfoIdentifier}
+    defaults: {_controller: support_tools.view.controller:viewInfoAction}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,7 +25,10 @@ services:
 
     support_tools.view.system_info_view_builder:
         class: EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder
-        arguments: [@support_tools.info_collectors.ezc_hardware]
+        arguments:
+            -
+                hardware: @support_tools.info_collectors.ezc_hardware
+                php: @support_tools.info_collectors.php
 
     support_tools.view.controller:
         class: EzSystems\EzSupportToolsBundle\Controller\SystemInfoController

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,3 +22,10 @@ services:
         class: %support_tools.info_collectors.php.ezc.class%
         arguments:
             - @support_tools.info_collector.system_info.ezc
+
+    support_tools.view.system_info_view_builder:
+        class: EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder
+        arguments: [@support_tools.info_collectors.ezc_hardware]
+
+    support_tools.view.controller:
+        class: EzSystems\EzSupportToolsBundle\Controller\SystemInfoController

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: view.yml }
+
 parameters:
     support_tools.info_collectors.database.doctrine.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
     support_tools.info_collectors.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
@@ -22,13 +25,3 @@ services:
         class: %support_tools.info_collectors.php.ezc.class%
         arguments:
             - @support_tools.info_collector.system_info.ezc
-
-    support_tools.view.system_info_view_builder:
-        class: EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder
-        arguments:
-            -
-                hardware: @support_tools.info_collectors.ezc_hardware
-                php: @support_tools.info_collectors.php
-
-    support_tools.view.controller:
-        class: EzSystems\EzSupportToolsBundle\Controller\SystemInfoController

--- a/Resources/config/view.yml
+++ b/Resources/config/view.yml
@@ -1,0 +1,25 @@
+services:
+    support_tools.view.system_info_view_builder:
+        class: EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder
+        arguments:
+            - @ezpublish.view.configurator
+            # temporary until we add a service tag (EZP-25598)
+            -
+                hardware: @support_tools.info_collectors.hardware.ezc
+                php: @support_tools.info_collectors.php.ezc
+
+    support_tools.view.controller:
+        class: EzSystems\EzSupportToolsBundle\Controller\SystemInfoController
+
+    support_tools.view.system_info.provider:
+        class: %ezpublish.view_provider.configured.class%
+        arguments: [@support_tools.view.matcher_factory]
+        tags:
+            - {name: ezpublish.view_provider, type: 'EzSystems\EzSupportToolsBundle\View\SystemInfoView', priority: 10}
+
+    support_tools.view.matcher_factory:
+        class: %ezpublish.view.matcher_factory.class%
+        arguments: [@ezpublish.api.repository, 'EzSystems\EzSupportToolsBundle\View\Matcher']
+        calls:
+            - [setContainer, [@service_container]]
+            - [setMatchConfig, [$system_info_view$]]

--- a/Tests/View/Matcher/SystemInfo/IdentitifierTest.php
+++ b/Tests/View/Matcher/SystemInfo/IdentitifierTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\Tests\View\Matcher\SystemInfo;
+
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Value\HardwareSystemInfo;
+use EzSystems\EzSupportToolsBundle\View\Matcher\SystemInfo\Identifier;
+use EzSystems\EzSupportToolsBundle\View\SystemInfoView;
+use PHPUnit_Framework_TestCase;
+
+class IdentitifierTest extends PHPUnit_Framework_TestCase
+{
+    public function testMatch()
+    {
+        $view = new SystemInfoView();
+        $view->setInfo(new HardwareSystemInfo());
+
+        $matcher = new Identifier();
+        $matcher->setMatchingConfig('hardware');
+
+        self::assertTrue($matcher->match($view));
+    }
+
+    public function testNoMatch()
+    {
+        $view = new SystemInfoView();
+        $view->setInfo(new HardwareSystemInfo());
+
+        $matcher = new Identifier();
+        $matcher->setMatchingConfig('php');
+
+        self::assertFalse($matcher->match($view));
+    }
+
+    public function testMatchOtherView()
+    {
+        $view = new ContentView();
+
+        $matcher = new Identifier();
+        $matcher->setMatchingConfig('test');
+
+        self::assertFalse($matcher->match($view));
+    }
+}

--- a/Tests/View/SystemInfoViewBuilderTest.php
+++ b/Tests/View/SystemInfoViewBuilderTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\Tests\View;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder;
+
+class SystemInfoViewBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    private $configuratorMock;
+
+    private $collectorMock;
+
+    public function testMatches()
+    {
+        $builder = new SystemInfoViewBuilder($this->getConfiguratorMock(), []);
+        self::assertTrue($builder->matches('support_tools.view.controller:viewInfoAction'));
+    }
+
+    public function testNotMatches()
+    {
+        $builder = new SystemInfoViewBuilder($this->getConfiguratorMock(), []);
+        self::assertFalse($builder->matches('service:someAction'));
+    }
+
+    public function testBuildView()
+    {
+        $builder = new SystemInfoViewBuilder(
+            $this->getConfiguratorMock(),
+            ['test' => $this->getCollectorMock()]
+        );
+
+        $systemInfo = $this->getMock('SystemInfo');
+
+        $this->getCollectorMock()
+            ->method('build')
+            ->will($this->returnValue($systemInfo));
+
+        $view = $builder->buildView(['systemInfoIdentifier' => 'test']);
+        self::assertSame($view->getInfo(), $systemInfo);
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     */
+    public function testBuildViewCollectorNotFound()
+    {
+        $builder = new SystemInfoViewBuilder($this->getConfiguratorMock(), []);
+        $builder->buildView(['systemInfoIdentifier' => 'test']);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\MVC\Symfony\View\Configurator
+     */
+    protected function getConfiguratorMock()
+    {
+        if (!isset($this->configuratorMock)) {
+            $this->configuratorMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\Configurator');
+        }
+
+        return $this->configuratorMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector
+     */
+    protected function getCollectorMock()
+    {
+        if (!isset($this->collectorMock)) {
+            $this->collectorMock = $this->getMock('EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector');
+        }
+
+        return $this->collectorMock;
+    }
+}

--- a/View/Matcher/SystemInfo/Identifier.php
+++ b/View/Matcher/SystemInfo/Identifier.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\View\Matcher\SystemInfo;
+
+use Doctrine\Common\Inflector\Inflector;
+use eZ\Publish\Core\MVC\Symfony\Matcher\ViewMatcherInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\EzSupportToolsBundle\View\SystemInfoView;
+
+class Identifier implements ViewMatcherInterface
+{
+    /**
+     * Matched SystemInfo identifier. Example: 'php', 'hardware'...
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * Registers the matching configuration for the matcher.
+     * It's up to the implementor to validate $matchingConfig since it can be anything configured by the end-developer.
+     *
+     * @param mixed $matchingConfig
+     *
+     * @throws \InvalidArgumentException Should be thrown if $matchingConfig is not valid.
+     */
+    public function setMatchingConfig($matchingConfig)
+    {
+        $this->identifier = $matchingConfig;
+    }
+
+    /**
+     * Matches the $view against a set of matchers.
+     *
+     * @param \EzSystems\EzSupportToolsBundle\View\SystemInfoView $view
+     *
+     * @return bool
+     */
+    public function match(View $view)
+    {
+        if (!$view instanceof SystemInfoView) {
+            return false;
+        }
+
+        return $this->toIdentifier($view->getInfo()) === $this->identifier;
+    }
+
+    private function toIdentifier($object)
+    {
+        $className = get_class($object);
+        $className = substr($className, strrpos($className, '\\') + 1);
+        $className = str_replace('SystemInfo', '', $className);
+
+        return Inflector::tableize($className);
+    }
+}

--- a/View/SystemInfoView.php
+++ b/View/SystemInfoView.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class SystemInfoView extends BaseView implements View
+{
+    /**
+     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\Value\SystemInfo
+     */
+    private $info;
+
+    /**
+     * @param \EzSystems\EzSupportToolsBundle\SystemInfo\Value\SystemInfo $info
+     *
+     * @return SystemInfoView
+     */
+    public function setInfo($info)
+    {
+        $this->info = $info;
+
+        return $this;
+    }
+
+    /**
+     * @return \EzSystems\EzSupportToolsBundle\SystemInfo\Value\SystemInfo
+     */
+    public function getInfo()
+    {
+        return $this->info;
+    }
+
+    protected function getInternalParameters()
+    {
+        return ['info' => $this->info];
+    }
+}

--- a/View/SystemInfoViewBuilder.php
+++ b/View/SystemInfoViewBuilder.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\View;
+
+use Doctrine\Common\Inflector\Inflector;
+use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector;
+
+class SystemInfoViewBuilder implements ViewBuilder
+{
+    /**
+     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector
+     */
+    private $infoCollector;
+
+    public function __construct(SystemInfoCollector $infoCollector)
+    {
+        $this->infoCollector = $infoCollector;
+    }
+
+    public function matches($argument)
+    {
+        return $argument === 'support_tools.view.controller:viewInfoAction';
+    }
+
+    public function buildView(array $parameters)
+    {
+        $view = new SystemInfoView();
+        $view->setInfo($this->infoCollector->build());
+        $view->setTemplateIdentifier(
+            $this->toTemplateIdentifier($view->getInfo())
+        );
+
+        return $view;
+    }
+
+    private function toTemplateIdentifier($object)
+    {
+        $className = get_class($object);
+        $className = substr($className, strrpos($className, '\\') + 1);
+
+        return Inflector::tableize($className) . ".html.twig";
+    }
+}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25579
> Working prototype, with all the hard requirements
> PlatformUI integration: https://github.com/ezsystems/PlatformUIBundle/pull/532
> ezplatform integration: https://github.com/ezsystems/ezplatform/compare/ezp25579-view_api_integration

### Contents
- `SystemInfoViewController` + `viewInfoAction`
- `/ez-support-tools/view/info/{identifier}` route. Identifier is the name of the class minus SystemInfo, underscorized: `PhpSystemInfo` :arrow_right: `php`
- `SystemInfoView` object + builder
- `SystemInfo\Identifier` view matcher

### Status
`/ez-support-tools/view/php` matches the SystemInfoController view action.
The template (property of the view) used to render the SystemInfoView is set depending on the view matchers configuration.

#### View configuration
The template used by each info type can be configured as for  `content_view`:

```
parameters:
    ezsettings.default.system_info_view:
        full:
            php:
                template: "ez-support-tools/info/php.html.twig"
                match:
                    SystemInfo\Identifier: "php"
            hardware:
                template: "ez-support-tools/info/hardware.html.twig"
                match:
                    SystemInfo\Identifier: "hardware"
```

#### View templates
The viewed `SystemInfo` object is provided as the `info` variable.

We don't intend to provide system info outside of a PlatformUI context for the time being. Therefore, the *pjax* view templates should be added to PlatformUI.

### Open questions

#### Permissions & security

How was this handled in PlatformUI ?
First, I think we can _maybe_ postpone that part: the package is still a 0.x, and we can easily document that in the readme.

As for implementing this, I'd lean towards real policies: we can have services around collectors that do check permissions using custom policies.


### Tasks
- [x] PlatformUI templates. The idea is that PlatformUI would use its own templates to implement pjax
- [x] Tests
- [x] Semantic config for system_info_view. But is it a hard requirement ?
- [x] Think about security/permissions