### PR TITLE
Fix EZP-25580: eZSupportTools PHP collector service naming fix

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,24 +1,24 @@
 parameters:
-    support_tools.info_collectors.doctrine_database.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
-    support_tools.info_collectors.ezc_hardware.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
-    support_tools.info_collectors.php.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector
+    support_tools.info_collectors.database.doctrine.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
+    support_tools.info_collectors.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
+    support_tools.info_collectors.php.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector
 
 services:
-    support_tools.info_collectors.doctrine_database:
-        class: %support_tools.info_collectors.doctrine_database.class%
+    support_tools.info_collector.system_info.ezc:
+        class: ezcSystemInfo
+        factory: [EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory, buildEzcSystemInfo]
+
+    support_tools.info_collectors.database.doctrine:
+        class: %support_tools.info_collectors.database.doctrine.class%
         arguments:
             - @database_connection
 
-    support_tools.info_collectors.ezc_hardware:
-        class: %support_tools.info_collectors.ezc_hardware.class%
+    support_tools.info_collectors.hardware.ezc:
+        class: %support_tools.info_collectors.hardware.ezc.class%
         arguments:
-            - @support_tools.info_collector.system_info.ezc_system_info
+            - @support_tools.info_collector.system_info.ezc
 
-    support_tools.info_collectors.php:
-        class: %support_tools.info_collectors.php.class%
+    support_tools.info_collectors.php.ezc:
+        class: %support_tools.info_collectors.php.ezc.class%
         arguments:
-            - @support_tools.info_collector.system_info.ezc_system_info
-
-    support_tools.info_collector.system_info.ezc_system_info:
-        class: ezcSystemInfo
-        factory: [EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory, buildEzcSystemInfo]
+            - @support_tools.info_collector.system_info.ezc


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25580
> Status: Ready for review

The service is named `support_tools.info_collectors.php`, but to be consistent with the class name and the hardware collector it should be named `support_tools.info_collectors.ezc_php`, as it uses the Components.

- [x] squash