### PR TITLE
Fix EZP-25607: eZSupportTools infocollector naming fix

### DIFF
--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -40,7 +40,7 @@ class SystemInfoDumpCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $infoCollector = $this->getContainer()->get($input->getArgument('info-collector'));
-        $infoValue = $infoCollector->build();
+        $infoValue = $infoCollector->collect();
 
         $outputArray = [];
         // attributes() is deprecated, and getProperties() is protected. Smeg it, this is very temporary anyway.

--- a/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollector.php
+++ b/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollector.php
@@ -29,7 +29,7 @@ class DoctrineDatabaseSystemInfoCollector implements SystemInfoCollector
     }
 
     /**
-     * Builds information about the database eZ Platform is using.
+     * Collects information about the database eZ Platform is using.
      *  - type
      *  - name
      *  - host
@@ -37,7 +37,7 @@ class DoctrineDatabaseSystemInfoCollector implements SystemInfoCollector
      *
      * @return Value\DatabaseSystemInfo
      */
-    public function build()
+    public function collect()
     {
         return new Value\DatabaseSystemInfo([
             'type' => $this->connection->getDatabasePlatform()->getName(),

--- a/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
@@ -29,13 +29,13 @@ class EzcHardwareSystemInfoCollector implements SystemInfoCollector
     }
 
     /**
-     * Builds information about the hardware eZ Platform is installed on.
+     * Collects information about the hardware eZ Platform is installed on.
      *  - cpu information
      *  - memory size
      *
      * @return Value\HardwareSystemInfo
      */
-    public function build()
+    public function collect()
     {
         return new Value\HardwareSystemInfo([
             'cpuType' => $this->ezcSystemInfo->cpuType,

--- a/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
@@ -29,13 +29,13 @@ class EzcPhpSystemInfoCollector implements SystemInfoCollector
     }
 
     /**
-     * Builds information about the PHP installation eZ Platform is using.
+     * Collects information about the PHP installation eZ Platform is using.
      *  - php version
      *  - php accelerator info
      *
      * @return Value\PhpSystemInfo
      */
-    public function build()
+    public function collect()
     {
         $properties = [
             'version' => phpversion(),

--- a/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
+++ b/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
@@ -40,13 +40,13 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
     }
 
     /**
-     * Builds information about installed composer packages.
+     * Collects information about installed composer packages.
      *
      * @throws Exception\ComposerLockFileNotFoundException if the composer.lock file was not found.
      *
      * @return Value\ComposerSystemInfo
      */
-    public function build()
+    public function collect()
     {
         if (!file_exists($this->lockFile)) {
             throw new Exception\ComposerLockFileNotFoundException($this->lockFile);

--- a/SystemInfo/Collector/SystemInfoCollector.php
+++ b/SystemInfo/Collector/SystemInfoCollector.php
@@ -16,9 +16,9 @@ use EzSystems\EzSupportToolsBundle\SystemInfo\Value;
 interface SystemInfoCollector
 {
     /**
-     * Builds system information.
+     * Collects system information.
      *
      * @return Value\SystemInfo
      */
-    public function build();
+    public function collect();
 }

--- a/Tests/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollectorTest.php
@@ -39,7 +39,10 @@ class DoctrineDatabaseSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
         $this->databaseCollector = new DoctrineDatabaseSystemInfoCollector($this->dbalConnectionMock);
     }
 
-    public function testBuild()
+    /**
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector::collect()
+     */
+    public function testCollect()
     {
         $expected = new DatabaseSystemInfo([
             'type' => 'mysql',
@@ -73,7 +76,7 @@ class DoctrineDatabaseSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
             ->method('getUsername')
             ->will($this->returnValue($expected->username));
 
-        $value = $this->databaseCollector->build();
+        $value = $this->databaseCollector->collect();
 
         self::assertInstanceOf('EzSystems\EzSupportToolsBundle\SystemInfo\Value\DatabaseSystemInfo', $value);
 

--- a/Tests/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
@@ -36,9 +36,12 @@ class EzcHardwareSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
         $this->ezcHardware = new EzcHardwareSystemInfoCollector($this->ezcSystemInfoMock);
     }
 
-    public function testBuild()
+    /**
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector::collect()
+     */
+    public function testCollect()
     {
-        $value = $this->ezcHardware->build();
+        $value = $this->ezcHardware->collect();
 
         self::assertInstanceOf('EzSystems\EzSupportToolsBundle\SystemInfo\Value\HardwareSystemInfo', $value);
 

--- a/Tests/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
@@ -43,9 +43,12 @@ class EzcPhpSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
         $this->ezcPhpCollector = new EzcPhpSystemInfoCollector($this->ezcSystemInfoMock);
     }
 
-    public function testBuild()
+    /**
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector::collect()
+     */
+    public function testCollect()
     {
-        $value = $this->ezcPhpCollector->build();
+        $value = $this->ezcPhpCollector->collect();
 
         self::assertInstanceOf('EzSystems\EzSupportToolsBundle\SystemInfo\Value\PhpSystemInfo', $value);
 

--- a/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -16,9 +16,9 @@ use PHPUnit_Framework_TestCase;
 class JsonComposerLockSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::build()
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
      */
-    public function testBuild()
+    public function testCollect()
     {
         $expected = new ComposerSystemInfo([
             'packages' => [
@@ -57,7 +57,7 @@ class JsonComposerLockSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
 
         $composerCollector = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock');
 
-        $value = $composerCollector->build();
+        $value = $composerCollector->collect();
 
         self::assertInstanceOf('EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo', $value);
 
@@ -65,14 +65,14 @@ class JsonComposerLockSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::build()
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
      *
      * @expectedException \EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException
      */
-    public function testBuildFileNotFound()
+    public function testCollectFileNotFound()
     {
         $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/snafu.lock');
 
-        $composerCollectorNotFound->build();
+        $composerCollectorNotFound->collect();
     }
 }


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25607
> Status: Ready for review

Rename `SystemInfoCollector::build()` to `collect()`.