### PR TITLE
Fix EZP-25598: eZSupportTools infocollector registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ branches:
         - master
 
 before_script:
-    - composer selfupdate
-    - composer install --prefer-dist
+    # re-enable when / if coverage is disabled for faster test runs
+    #- phpenv config-rm xdebug.ini
+    - travis_retry composer selfupdate
+    # Avoid memory issues on composer install
+    - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - travis_retry composer install --prefer-dist --no-interaction
 
-script: phpunit --coverage-text
+script: php bin/phpunit --coverage-text
 
 notifications:
     email: false

--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -8,13 +8,30 @@
  */
 namespace EzSystems\EzSupportToolsBundle\Command;
 
+use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector;
+use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SystemInfoDumpCommand extends ContainerAwareCommand
 {
+    /**
+     * System info collector registry.
+     *
+     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry
+     */
+    private $registry;
+
+    public function __construct(SystemInfoCollectorRegistry $registry)
+    {
+        $this->registry = $registry;
+
+        parent::__construct();
+    }
+
     /**
      * Define command and input options.
      */
@@ -23,10 +40,22 @@ class SystemInfoDumpCommand extends ContainerAwareCommand
         $this
             ->setName('ez-support-tools:dump-info')
             ->setDescription('Collects system information and dumps it.')
+            ->setHelp(<<<'EOD'
+By default it dumps information from all available information collectors.
+You can specify one or more collectors as arguments, e.g. 'php database hardware'.
+To get a list if available collectors, use '--list-info-collectors'
+EOD
+            )
+            ->addOption(
+                'list-info-collectors',
+                null,
+                InputOption::VALUE_NONE,
+                'List all available information collectors, and exit.'
+            )
             ->addArgument(
-                'info-collector',
-                InputArgument::REQUIRED,
-                'Which information collector should be used?'
+                'info-collectors',
+                InputArgument::IS_ARRAY,
+                'Which information collector(s) should be used? (separate multiple names with spaces)'
             )
             ;
     }
@@ -39,11 +68,37 @@ class SystemInfoDumpCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $infoCollector = $this->getContainer()->get($input->getArgument('info-collector'));
+        if ($input->getOption('list-info-collectors')) {
+            $output->writeln('Available info collectors:', true);
+            foreach ($this->registry->getIdentifiers() as $identifier) {
+                $output->writeln("  $identifier", true);
+            }
+        } else if ($identifiers = $input->getArgument('info-collectors')) {
+            foreach ($identifiers as $identifier) {
+                $this->outputInfo(
+                    $this->registry->getItem($identifier),
+                    $output
+                );
+            }
+        } else {
+            foreach ($this->registry->getIdentifiers() as $identifier) {
+                $this->outputInfo($this->registry->getItem($identifier), $output);
+            }
+        }
+    }
+
+    /**
+     * Output info collected by the given collector.
+     *
+     * @param $infoCollector SystemInfoCollector
+     * @param $output OutputInterface
+     */
+    private function outputInfo(SystemInfoCollector $infoCollector, OutputInterface $output)
+    {
         $infoValue = $infoCollector->collect();
 
         $outputArray = [];
-        // attributes() is deprecated, and getProperties() is protected. Smeg it, this is very temporary anyway.
+        // attributes() is deprecated, and getProperties() is protected. TODO add a toArray() or similar.
         foreach ($infoValue->attributes() as $property) {
             $outputArray[$property] = $infoValue->$property;
         }

--- a/DependencyInjection/Compiler/SystemInfoCollectorPass.php
+++ b/DependencyInjection/Compiler/SystemInfoCollectorPass.php
@@ -21,20 +21,20 @@ class SystemInfoCollectorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('support_tools.info_collector.registry')) {
+        if (!$container->has('support_tools.system_info.collector_registry')) {
             return;
         }
 
-        $infoCollectorsTagged = $container->findTaggedServiceIds('support_tools.info_collector');
+        $infoCollectorsTagged = $container->findTaggedServiceIds('support_tools.system_info.collector');
 
         $infoCollectors = [];
         foreach ($infoCollectorsTagged as $id => $tags) {
             foreach ($tags as $attributes) {
-                $infoCollectors[$attributes['alias']] = new Reference($id);
+                $infoCollectors[$attributes['identifier']] = new Reference($id);
             }
         }
 
-        $infoCollectorRegistryDef = $container->findDefinition('support_tools.info_collector.registry');
+        $infoCollectorRegistryDef = $container->findDefinition('support_tools.system_info.collector_registry');
         $infoCollectorRegistryDef->setArguments([$infoCollectors]);
     }
 }

--- a/DependencyInjection/Compiler/SystemInfoCollectorPass.php
+++ b/DependencyInjection/Compiler/SystemInfoCollectorPass.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * File containing the SystemInfoCollectorPass class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class SystemInfoCollectorPass implements CompilerPassInterface
+{
+    /**
+     * Registers the SystemInfoCollector into the system info collector registry.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('support_tools.info_collector.registry')) {
+            return;
+        }
+
+        $infoCollectorsTagged = $container->findTaggedServiceIds('support_tools.info_collector');
+
+        $infoCollectors = [];
+        foreach ($infoCollectorsTagged as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $infoCollectors[$attributes['alias']] = new Reference($id);
+            }
+        }
+
+        $infoCollectorRegistryDef = $container->findDefinition('support_tools.info_collector.registry');
+        $infoCollectorRegistryDef->setArguments([$infoCollectors]);
+    }
+}

--- a/EzSystemsEzSupportToolsBundle.php
+++ b/EzSystemsEzSupportToolsBundle.php
@@ -8,6 +8,7 @@
  */
 namespace EzSystems\EzSupportToolsBundle;
 
+use EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler\SystemInfoCollectorPass;
 use EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler\ViewBuilderPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -17,6 +18,7 @@ class EzSystemsEzSupportToolsBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+        $container->addCompilerPass(new SystemInfoCollectorPass());
         $container->addCompilerPass(new ViewBuilderPass());
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,6 +4,7 @@ imports:
 parameters:
     support_tools.command.dump_info.class: EzSystems\EzSupportToolsBundle\Command\SystemInfoDumpCommand
     support_tools.info_collector.registry.class: EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased
+    support_tools.info_collector.system_info.ezc.factory.class: EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory
     support_tools.info_collectors.composer.lock_file.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector
     support_tools.info_collectors.database.doctrine.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
     support_tools.info_collectors.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
@@ -23,7 +24,11 @@ services:
 
     support_tools.info_collector.system_info.ezc:
         class: ezcSystemInfo
-        factory: [EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory, buildEzcSystemInfo]
+        factory: [@support_tools.info_collector.system_info.ezc.factory, buildEzcSystemInfo]
+
+    support_tools.info_collector.system_info.ezc.factory:
+        class: %support_tools.info_collector.system_info.ezc.factory.class%
+        lazy: true
 
     support_tools.info_collectors.composer.lock_file:
         class: %support_tools.info_collectors.composer.lock_file.class%

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: view.yml }
 
 parameters:
+    support_tools.command.dump_info.class: EzSystems\EzSupportToolsBundle\Command\SystemInfoDumpCommand
     support_tools.info_collector.registry.class: EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased
     support_tools.info_collectors.composer.lock_file.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector
     support_tools.info_collectors.database.doctrine.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
@@ -10,6 +11,13 @@ parameters:
     support_tools.info_collectors.symfony.kernel.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollector
 
 services:
+    support_tools.command.dump_info:
+        class: %support_tools.command.dump_info.class%
+        arguments:
+            - @support_tools.info_collector.registry
+        tags:
+            - { name: console.command }
+
     support_tools.info_collector.registry:
         class: %support_tools.info_collector.registry.class%
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,65 +3,68 @@ imports:
 
 parameters:
     support_tools.command.dump_info.class: EzSystems\EzSupportToolsBundle\Command\SystemInfoDumpCommand
-    support_tools.info_collector.registry.class: EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased
-    support_tools.info_collector.system_info.ezc.factory.class: EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory
-    support_tools.info_collectors.composer.lock_file.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector
-    support_tools.info_collectors.database.doctrine.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
-    support_tools.info_collectors.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
-    support_tools.info_collectors.php.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector
-    support_tools.info_collectors.symfony.kernel.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollector
+    support_tools.system_info.collector_registry.class: EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased
+    support_tools.system_info.ezc.factory.class: EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory
+    support_tools.system_info.collector.composer.lock_file.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector
+    support_tools.system_info.collector.database.doctrine.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
+    support_tools.system_info.collector.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
+    support_tools.system_info.collector.php.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector
+    support_tools.system_info.collector.symfony.kernel.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollector
 
 services:
     support_tools.command.dump_info:
         class: %support_tools.command.dump_info.class%
         arguments:
-            - @support_tools.info_collector.registry
+            - @support_tools.system_info.collector_registry
         tags:
             - { name: console.command }
 
-    support_tools.info_collector.registry:
-        class: %support_tools.info_collector.registry.class%
+    support_tools.system_info.collector_registry:
+        class: %support_tools.system_info.collector_registry.class%
 
-    support_tools.info_collector.system_info.ezc:
+    support_tools.system_info.ezc:
         class: ezcSystemInfo
-        factory: [@support_tools.info_collector.system_info.ezc.factory, buildEzcSystemInfo]
+        factory: [@support_tools.system_info.ezc.factory, buildEzcSystemInfo]
 
-    support_tools.info_collector.system_info.ezc.factory:
-        class: %support_tools.info_collector.system_info.ezc.factory.class%
+    support_tools.system_info.ezc.factory:
+        class: %support_tools.system_info.ezc.factory.class%
         lazy: true
 
-    support_tools.info_collectors.composer.lock_file:
-        class: %support_tools.info_collectors.composer.lock_file.class%
+
+    # SystemInfoCollectors
+
+    support_tools.system_info.collector.composer.lock_file:
+        class: %support_tools.system_info.collector.composer.lock_file.class%
         arguments:
             - "%kernel.root_dir%/../composer.lock"
         tags:
-            - { name: "support_tools.info_collector", alias: "composer" }
+            - { name: "support_tools.system_info.collector", identifier: "composer" }
 
-    support_tools.info_collectors.database.doctrine:
-        class: %support_tools.info_collectors.database.doctrine.class%
+    support_tools.system_info.collector.database.doctrine:
+        class: %support_tools.system_info.collector.database.doctrine.class%
         arguments:
             - @database_connection
         tags:
-            - { name: "support_tools.info_collector", alias: "database" }
+            - { name: "support_tools.system_info.collector", identifier: "database" }
 
-    support_tools.info_collectors.hardware.ezc:
-        class: %support_tools.info_collectors.hardware.ezc.class%
+    support_tools.system_info.collector.hardware.ezc:
+        class: %support_tools.system_info.collector.hardware.ezc.class%
         arguments:
-            - @support_tools.info_collector.system_info.ezc
+            - @support_tools.system_info.ezc
         tags:
-            - { name: "support_tools.info_collector", alias: "hardware" }
+            - { name: "support_tools.system_info.collector", identifier: "hardware" }
 
-    support_tools.info_collectors.php.ezc:
-        class: %support_tools.info_collectors.php.ezc.class%
+    support_tools.system_info.collector.php.ezc:
+        class: %support_tools.system_info.collector.php.ezc.class%
         arguments:
-            - @support_tools.info_collector.system_info.ezc
+            - @support_tools.system_info.ezc
         tags:
-            - { name: "support_tools.info_collector", alias: "php" }
+            - { name: "support_tools.system_info.collector", identifier: "php" }
 
-    support_tools.info_collectors.symfony.kernel.config:
-        class: %support_tools.info_collectors.symfony.kernel.config.class%
+    support_tools.system_info.collector.symfony.kernel.config:
+        class: %support_tools.system_info.collector.symfony.kernel.config.class%
         arguments:
             - @kernel
             - %kernel.bundles%
         tags:
-            - { name: "support_tools.info_collector", alias: "symfony_kernel" }
+            - { name: "support_tools.system_info.collector", identifier: "symfony_kernel" }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: view.yml }
 
 parameters:
+    support_tools.info_collector.registry.class: EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased
     support_tools.info_collectors.composer.lock_file.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector
     support_tools.info_collectors.database.doctrine.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector
     support_tools.info_collectors.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
@@ -9,6 +10,9 @@ parameters:
     support_tools.info_collectors.symfony.kernel.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollector
 
 services:
+    support_tools.info_collector.registry:
+        class: %support_tools.info_collector.registry.class%
+
     support_tools.info_collector.system_info.ezc:
         class: ezcSystemInfo
         factory: [EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoFactory, buildEzcSystemInfo]
@@ -17,24 +21,34 @@ services:
         class: %support_tools.info_collectors.composer.lock_file.class%
         arguments:
             - "%kernel.root_dir%/../composer.lock"
+        tags:
+            - { name: "support_tools.info_collector", alias: "composer" }
 
     support_tools.info_collectors.database.doctrine:
         class: %support_tools.info_collectors.database.doctrine.class%
         arguments:
             - @database_connection
+        tags:
+            - { name: "support_tools.info_collector", alias: "database" }
 
     support_tools.info_collectors.hardware.ezc:
         class: %support_tools.info_collectors.hardware.ezc.class%
         arguments:
             - @support_tools.info_collector.system_info.ezc
+        tags:
+            - { name: "support_tools.info_collector", alias: "hardware" }
 
     support_tools.info_collectors.php.ezc:
         class: %support_tools.info_collectors.php.ezc.class%
         arguments:
             - @support_tools.info_collector.system_info.ezc
+        tags:
+            - { name: "support_tools.info_collector", alias: "php" }
 
     support_tools.info_collectors.symfony.kernel.config:
         class: %support_tools.info_collectors.symfony.kernel.config.class%
         arguments:
             - @kernel
             - %kernel.bundles%
+        tags:
+            - { name: "support_tools.info_collector", alias: "symfony_kernel" }

--- a/Resources/config/view.yml
+++ b/Resources/config/view.yml
@@ -3,7 +3,7 @@ services:
         class: EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder
         arguments:
             - @ezpublish.view.configurator
-            - @support_tools.info_collector.registry
+            - @support_tools.system_info.collector_registry
 
     support_tools.view.controller:
         class: EzSystems\EzSupportToolsBundle\Controller\SystemInfoController

--- a/Resources/config/view.yml
+++ b/Resources/config/view.yml
@@ -3,10 +3,7 @@ services:
         class: EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder
         arguments:
             - @ezpublish.view.configurator
-            # temporary until we add a service tag (EZP-25598)
-            -
-                hardware: @support_tools.info_collectors.hardware.ezc
-                php: @support_tools.info_collectors.php.ezc
+            - @support_tools.info_collector.registry
 
     support_tools.view.controller:
         class: EzSystems\EzSupportToolsBundle\Controller\SystemInfoController

--- a/SystemInfo/Registry/IdentifierBased.php
+++ b/SystemInfo/Registry/IdentifierBased.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * File containing the IdentifierBased class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Registry;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
+
+/**
+ * A registry of SystemInfoCollectors that uses an identifier string to identify the collector.
+ */
+class IdentifierBased implements SystemInfoCollectorRegistry
+{
+    /** @var \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector[] */
+    private $registry = [];
+
+    /**
+     * @param \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector[] $items Hash of SystemInfoCollectors, with identifier string as key.
+     */
+    public function __construct(array $items = [])
+    {
+        $this->registry = $items;
+    }
+
+    /**
+     * Returns the SystemInfoCollector matching the argument.
+     *
+     * @param string $identifier An identifier string.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException If no SystemInfoCollector exists with this identifier
+     *
+     * @return \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector The SystemInfoCollector given by the identifier.
+     */
+    public function getItem($identifier)
+    {
+        if (isset($this->registry[$identifier])) {
+            return $this->registry[$identifier];
+        }
+
+        throw new NotFoundException("A SystemInfo collector could not be found.", $identifier);
+    }
+
+    /**
+     * Returns the identifiers of all registered SystemInfoCollectors.
+     *
+     * @return string[] Array of identifier strings.
+     */
+    public function getIdentifiers()
+    {
+        return array_keys($this->registry);
+    }
+}

--- a/SystemInfo/SystemInfoCollectorRegistry.php
+++ b/SystemInfo/SystemInfoCollectorRegistry.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * File containing the SystemInfoCollectorRegistry interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo;
+
+/**
+ * A registry of SystemInfoCollectors.
+ */
+interface SystemInfoCollectorRegistry
+{
+    /**
+     * @param \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector[] $items Hash of SystemInfoCollectors, with identifier string as key.
+     */
+    public function __construct(array $items = []);
+
+    /**
+     * Returns the SystemInfoCollector matching the argument.
+     *
+     * @param string $identifier An identifier string.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException If no SystemInfoCollector exists with this identifier
+     *
+     * @return \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector The SystemInfoCollector given by the identifier.
+     */
+    public function getItem($identifier);
+
+    /**
+     * Returns the identifiers of all registered SystemInfoCollectors.
+     *
+     * @return string[] Array of identifier strings.
+     */
+    public function getIdentifiers();
+}

--- a/Tests/SystemInfo/Registry/IdentifierBasedTest.php
+++ b/Tests/SystemInfo/Registry/IdentifierBasedTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * File containing the IdentifierBasedTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Registry;
+
+use EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased;
+
+class IdentifierBasedTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBasedEzcPhpSystemInfoCollector
+     */
+    private $registry;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject[]|\EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector[]
+     */
+    private $testItems;
+
+    public function setUp()
+    {
+        $this->testItems = [
+            'foo' => $this->getMock('EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector'),
+            'bar' => $this->getMock('EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector'),
+        ];
+
+        $this->registry = new IdentifierBased();
+    }
+
+    /**
+     * Test adding items to the registry, and getting items from it.
+     *
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased::getItem()
+     */
+    public function testAddAndGetItems()
+    {
+        $this->registry = new IdentifierBased($this->testItems);
+
+        self::assertSame($this->testItems['foo'], $this->registry->getItem('foo'));
+        self::assertSame($this->testItems['bar'], $this->registry->getItem('bar'));
+    }
+
+    /**
+     * Test exception when registry item is not found.
+     *
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased::getItem()
+     *
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     */
+    public function testGetItemNotFound()
+    {
+        $this->registry->getItem('notfound');
+    }
+
+    /**
+     * Test replacing an item in the registry.
+     *
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased::getItem()
+     */
+    public function testReplaceItem()
+    {
+        $this->registry = new IdentifierBased($this->testItems);
+
+        $replaceItems = [
+            'foo' => $this->getMock('EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector'),
+        ];
+
+        $this->registry = new IdentifierBased($replaceItems);
+
+        self::assertNotSame($this->testItems['foo'], $this->registry->getItem('foo'));
+        self::assertSame($replaceItems['foo'], $this->registry->getItem('foo'));
+    }
+
+    /**
+     * Test getting all registered identifiers.
+     *
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased::getIdentifiers()
+     * @depends testAddAndGetItems
+     */
+    public function testGetIdentifiers()
+    {
+        $this->registry = new IdentifierBased($this->testItems);
+
+        $expectedIdentifiers = array_keys($this->testItems);
+        sort($expectedIdentifiers);
+
+        $actualIdentifiers = $this->registry->getIdentifiers();
+        sort($actualIdentifiers);
+
+        self::assertEquals($expectedIdentifiers, $actualIdentifiers);
+    }
+}

--- a/View/SystemInfoViewBuilder.php
+++ b/View/SystemInfoViewBuilder.php
@@ -4,27 +4,29 @@
  */
 namespace EzSystems\EzSupportToolsBundle\View;
 
-use Doctrine\Common\Inflector\Inflector;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector;
+use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
 
 class SystemInfoViewBuilder implements ViewBuilder
 {
-    /**
-     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector[]
-     */
-    private $infoCollectors;
     /**
      * @var \eZ\Publish\Core\MVC\Symfony\View\Configurator
      */
     private $viewConfigurator;
 
-    public function __construct(Configurator $viewConfigurator, array $infoCollectors)
+    /**
+     * System info collector registry.
+     *
+     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry
+     */
+    private $registry;
+
+    public function __construct(Configurator $viewConfigurator, SystemInfoCollectorRegistry $registry)
     {
-        $this->infoCollectors = $infoCollectors;
         $this->viewConfigurator = $viewConfigurator;
+        $this->registry = $registry;
     }
 
     public function matches($argument)
@@ -47,14 +49,9 @@ class SystemInfoViewBuilder implements ViewBuilder
      * @param string $identifier A SystemInfo collector identifier (php, hardware...)
      *
      * @return \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException If no SystemInfoCollector exists with this identifier
      */
     private function getCollector($identifier)
     {
-        if (!isset($this->infoCollectors[$identifier])) {
-            throw new NotFoundException("A SystemInfo collector could not be found.", $identifier);
-        }
-
-        return $this->infoCollectors[$identifier];
+        return $this->registry->getItem($identifier);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,11 @@
         "branch-alias": {
             "dev-master": "0.1.x-dev"
         }
+    },
+    "config": {
+        "bin-dir": "bin"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.7"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
     ],
     "require": {
         "ezsystems/ezpublish-kernel": "^6.2",
+        "ocramius/proxy-manager": "~1.0",
+        "symfony/proxy-manager-bridge": "*",
         "zetacomponents/system-information": "^1.1"
     },
     "autoload": {


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-25598
> Status: Ready for review

This does not implement infocollector descriptions, that's not needed/important (at least for now).

- [x] Implement the registry
- [x] Update the dump command to work with the registry
- [x] Update the View to work with the registry
- [x] Make the dump command a service and inject the registry
- [x] Testing