### PR TITLE
Added default system_info_view settings

### DIFF
--- a/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -22,5 +22,6 @@ class EzSystemsEzSupportToolsExtension extends Extension
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+        $loader->load('default_settings.yml');
     }
 }

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -1,0 +1,2 @@
+parameters:
+    ezsettings.default.system_info_view: {}


### PR DESCRIPTION
Avoids this error:

```
  [eZ\Publish\Core\MVC\Exception\ParameterNotFoundException]
  Parameter 'system_info_view' with namespace '' could not be found.
```