### PR TITLE
Made the builder pass the viewType to the SystemInfoView

### DIFF
--- a/Tests/View/SystemInfoViewBuilderTest.php
+++ b/Tests/View/SystemInfoViewBuilderTest.php
@@ -38,8 +38,9 @@ class SystemInfoViewBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('collect')
             ->will($this->returnValue($systemInfo));
 
-        $view = $builder->buildView(['systemInfoIdentifier' => 'test']);
+        $view = $builder->buildView(['systemInfoIdentifier' => 'test', 'viewType' => 'test']);
         self::assertSame($view->getInfo(), $systemInfo);
+        self::assertEquals($view->getViewType(), 'test');
     }
 
     /**

--- a/View/SystemInfoViewBuilder.php
+++ b/View/SystemInfoViewBuilder.php
@@ -35,7 +35,7 @@ class SystemInfoViewBuilder implements ViewBuilder
     public function buildView(array $parameters)
     {
         $collector = $this->getCollector($parameters['systemInfoIdentifier']);
-        $view = new SystemInfoView();
+        $view = new SystemInfoView(null, [], $parameters['viewType']);
         $view->setInfo($collector->collect());
 
         $this->viewConfigurator->configure($view);


### PR DESCRIPTION
Allows custom viewType usage:

```twig
{{ render( 
  controller( 
    "support_tools.view.controller:viewInfoAction",
    { "systemInfoIdentifier": "php", "viewType": "custom_view" } 
  ) 
) }}
```