### PR TITLE
EZP-25653: Allow use of eZSupportTools in PlatformUI

### DIFF
--- a/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -22,6 +22,5 @@ class EzSystemsEzSupportToolsExtension extends Extension
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
-        $loader->load('default_settings.yml');
     }
 }

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -1,2 +1,0 @@
-parameters:
-    ezsettings.default.system_info_view: {}


### PR DESCRIPTION
> Part of https://jira.ez.no/browse/EZP-25653
> Status: Ready for review

Removed default_settings.yml as it conflicts with the same in platformui (it resets the collectors).
Ref https://github.com/ezsystems/PlatformUIBundle/pull/542