### PR TITLE
Remove unused system_info_view route

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,3 +1,0 @@
-ez_support_tools_system_info_view:
-    path: /ez-support-tools/view/{systemInfoIdentifier}
-    defaults: {_controller: support_tools.view.controller:viewInfoAction}


### PR DESCRIPTION
> Fixing issue found in https://jira.ez.no/browse/EZP-25653
> See also: ezplatform PR: https://github.com/ezsystems/ezplatform/pull/106
> Status: Ready for review

The system_info_view route is not used, and has no access control, this removes it.