### PR TITLE
EZP-26549: Output pretty JSON in dump-info command

### DIFF
--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -73,36 +73,17 @@ EOD
             foreach ($this->registry->getIdentifiers() as $identifier) {
                 $output->writeln("  $identifier", true);
             }
-        } else if ($identifiers = $input->getArgument('info-collectors')) {
-            foreach ($identifiers as $identifier) {
-                $this->outputInfo(
-                    $this->registry->getItem($identifier),
-                    $output
-                );
-            }
+        } else if ($input->getArgument('info-collectors')) {
+            $identifiers = $input->getArgument('info-collectors');
         } else {
-            foreach ($this->registry->getIdentifiers() as $identifier) {
-                $this->outputInfo($this->registry->getItem($identifier), $output);
-            }
-        }
-    }
-
-    /**
-     * Output info collected by the given collector.
-     *
-     * @param $infoCollector SystemInfoCollector
-     * @param $output OutputInterface
-     */
-    private function outputInfo(SystemInfoCollector $infoCollector, OutputInterface $output)
-    {
-        $infoValue = $infoCollector->collect();
-
-        $outputArray = [];
-        // attributes() is deprecated, and getProperties() is protected. TODO add a toArray() or similar.
-        foreach ($infoValue->attributes() as $property) {
-            $outputArray[$property] = $infoValue->$property;
+            $identifiers = $this->registry->getIdentifiers();
         }
 
-        $output->writeln(var_export($outputArray, true));
+        $collectedInfo = [];
+        foreach ($identifiers as $identifier) {
+            $collectedInfo[$identifier] = $this->registry->getItem($identifier)->collect();
+        }
+
+        $output->writeln(json_encode($collectedInfo, JSON_PRETTY_PRINT));
     }
 }

--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -73,17 +73,19 @@ EOD
             foreach ($this->registry->getIdentifiers() as $identifier) {
                 $output->writeln("  $identifier", true);
             }
-        } else if ($input->getArgument('info-collectors')) {
-            $identifiers = $input->getArgument('info-collectors');
         } else {
-            $identifiers = $this->registry->getIdentifiers();
-        }
+            if ($input->getArgument('info-collectors')) {
+                $identifiers = $input->getArgument('info-collectors');
+            } else {
+                $identifiers = $this->registry->getIdentifiers();
+            }
 
-        $collectedInfo = [];
-        foreach ($identifiers as $identifier) {
-            $collectedInfo[$identifier] = $this->registry->getItem($identifier)->collect();
-        }
+            $collectedInfo = [];
+            foreach ($identifiers as $identifier) {
+                $collectedInfo[$identifier] = $this->registry->getItem($identifier)->collect();
+            }
 
-        $output->writeln(json_encode($collectedInfo, JSON_PRETTY_PRINT));
+            $output->writeln(json_encode($collectedInfo, JSON_PRETTY_PRINT));
+        }
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26549

Current output format uses multiple calls to `var_export`, which has two problems:
- It does not identify the "name" of the information category/collector.
- It uses a "not-that-common" format that is not as easily parsed/processed by some tools as it could be:

```
array (
  'type' => 'mysql',
  'name' => 'ezenterprise14',
  'host' => 'localhost',
  'username' => 'root',
)
array (
  'cpuType' => 'Intel(R) Core(TM) i5-2410M CPU @ 2.30GHz',
  'cpuSpeed' => 2294.7860000000001,
  'cpuCount' => 2,
  'memorySize' => 1577353216,
)
array (
  'version' => '5.6.20-0+deb8u1',
  'acceleratorEnabled' => true,
  'acceleratorName' => 'Zend OPcache',
  'acceleratorURL' => 'http://www.php.net/opcache',
  'acceleratorVersion' => '7.0.6-devFE',
)
```

This changes the output format to a single json object, with tries to solve both problems:

``` json
{
    "database": {
        "type": "mysql",
        "name": "ezenterprise14",
        "host": "localhost",
        "username": "root"
    },
    "hardware": {
        "cpuType": "Intel(R) Core(TM) i5-2410M CPU @ 2.30GHz",
        "cpuSpeed": 2294.786,
        "cpuCount": 2,
        "memorySize": 1577353216
    },
    "php": {
        "version": "5.6.20-0+deb8u1",
        "acceleratorEnabled": true,
        "acceleratorName": "Zend OPcache",
        "acceleratorURL": "http:\/\/www.php.net\/opcache",
        "acceleratorVersion": "7.0.6-devFE"
    }
}
```
