### PR TITLE
[Composer] Allowed ezpublish-kernel ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.2",
+        "ezsystems/ezpublish-kernel": "^6.2 || ^7.0",
         "ocramius/proxy-manager": "~1.0|~2.0",
         "symfony/proxy-manager-bridge": "*",
         "zetacomponents/system-information": "^1.1"


### PR DESCRIPTION
This PR allows `ezpublish-kernel:^7.0@dev` for `ez-support-tools`.

Reason: Right now we have to make workaround to install `ezplatform:2.0` meta-repository dependencies by setting requirement for `ezpublish-kernel` in the form of `7.0.x-dev as 6.99.x-dev` instead of simply `^7.0@dev`. This change solves that partially (see also: ezsystems/ezplatform-http-cache#16).