### PR TITLE
EZP-28161: Enable php-cs-fixer aligned with v2.7.1 settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,37 @@
+<?php
+
+// PHP-CS-Fixer 2.x syntax
+return PhpCsFixer\Config::create()
+    ->setRules(
+        [
+            '@Symfony' => true,
+            '@Symfony:risky' => true,
+            'concat_space' => ['spacing' => 'one'],
+            'array_syntax' => false,
+            'simplified_null_return' => false,
+            'phpdoc_align' => false,
+            'phpdoc_separation' => false,
+            'phpdoc_to_comment' => false,
+            'cast_spaces' => false,
+            'blank_line_after_opening_tag' => false,
+            'single_blank_line_before_namespace' => false,
+            'phpdoc_annotation_without_dot' => false,
+            'phpdoc_no_alias_tag' => false,
+            'space_after_semicolon' => false,
+            'yoda_style' => false,
+            'no_break_comment' => false,
+        ]
+    )
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->exclude(
+                [
+                    'bin',
+                    'Resources',
+                    'vendor',
+                ]
+            )
+            ->files()->name('*.php')
+    );

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ before_script:
     - travis_retry composer selfupdate
     # Avoid memory issues on composer install
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    # Install packages
     - travis_retry composer install --prefer-dist --no-interaction
 
 script:
     - php bin/phpunit --coverage-text
-    - if [ "$CHECK_CS" == "true" ]; then bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
+    - if [ "$CHECK_CS" == "true" ]; then phpenv config-rm xdebug.ini && bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
         - php: 5.6
         - php: 7.0
         - php: 7.1
+          env: CHECK_CS=true
 
 # test only master (+ Pull requests)
 branches:
@@ -19,7 +20,9 @@ before_script:
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - travis_retry composer install --prefer-dist --no-interaction
 
-script: php bin/phpunit --coverage-text
+script:
+    - php bin/phpunit --coverage-text
+    - if [ "$CHECK_CS" == "true" ]; then bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 
-php:
-    - 5.5
-    - 5.6
-    - 7.0
+matrix:
+    include:
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
 
 # test only master (+ Pull requests)
 branches:

--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -8,7 +8,6 @@
  */
 namespace EzSystems\EzSupportToolsBundle\Command;
 
-use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector;
 use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
 use EzSystems\EzSupportToolsBundle\SystemInfo\OutputFormatRegistry;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -82,35 +81,35 @@ EOD
      * @param $input InputInterface
      * @param $output OutputInterface
      */
-     protected function execute(InputInterface $input, OutputInterface $output)
-     {
-         if ($input->getOption('list-info-collectors')) {
-             $output->writeln('Available info collectors:', true);
-             foreach ($this->systemInfoCollectorRegistry->getIdentifiers() as $identifier) {
-                 $output->writeln("  $identifier", true);
-             }
-             return;
-         }
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getOption('list-info-collectors')) {
+            $output->writeln('Available info collectors:', true);
+            foreach ($this->systemInfoCollectorRegistry->getIdentifiers() as $identifier) {
+                $output->writeln("  $identifier", true);
+            }
 
-         $outputFormatter = $this->outputFormatRegistry->getItem(
+            return;
+        }
+
+        $outputFormatter = $this->outputFormatRegistry->getItem(
             $input->getOption('format')
          );
 
-         if ($input->getArgument('info-collectors')) {
-             $identifiers = $input->getArgument('info-collectors');
-         } else {
-             $identifiers = $this->systemInfoCollectorRegistry->getIdentifiers();
-         }
+        if ($input->getArgument('info-collectors')) {
+            $identifiers = $input->getArgument('info-collectors');
+        } else {
+            $identifiers = $this->systemInfoCollectorRegistry->getIdentifiers();
+        }
 
-         // Collect info for the given identifiers.
-         $collectedInfoArray = [];
-         foreach ($identifiers as $identifier) {
-             $collectedInfoArray[$identifier] = $this->systemInfoCollectorRegistry->getItem($identifier)->collect();
-         }
+        // Collect info for the given identifiers.
+        $collectedInfoArray = [];
+        foreach ($identifiers as $identifier) {
+            $collectedInfoArray[$identifier] = $this->systemInfoCollectorRegistry->getItem($identifier)->collect();
+        }
 
-         $output->writeln(
+        $output->writeln(
              $outputFormatter->format($collectedInfoArray)
          );
-     }
-
+    }
 }

--- a/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -20,7 +20,7 @@ class EzSystemsEzSupportToolsExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('default_settings.yml');
     }

--- a/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollector.php
+++ b/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollector.php
@@ -33,7 +33,7 @@ class DoctrineDatabaseSystemInfoCollector implements SystemInfoCollector
      *  - type
      *  - name
      *  - host
-     *  - username
+     *  - username.
      *
      * @return Value\DatabaseSystemInfo
      */

--- a/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
@@ -29,7 +29,7 @@ class EzcHardwareSystemInfoCollector implements SystemInfoCollector
     /**
      * Collects information about the hardware eZ Platform is installed on.
      *  - cpu information
-     *  - memory size
+     *  - memory size.
      *
      * @return Value\HardwareSystemInfo
      */

--- a/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
@@ -29,14 +29,14 @@ class EzcPhpSystemInfoCollector implements SystemInfoCollector
     /**
      * Collects information about the PHP installation eZ Platform is using.
      *  - php version
-     *  - php accelerator info
+     *  - php accelerator info.
      *
      * @return Value\PhpSystemInfo
      */
     public function collect()
     {
         $properties = [
-            'version' => phpversion(),
+            'version' => PHP_VERSION,
             'acceleratorEnabled' => false,
         ];
 

--- a/SystemInfo/EzcSystemInfoWrapper.php
+++ b/SystemInfo/EzcSystemInfoWrapper.php
@@ -26,7 +26,7 @@ class EzcSystemInfoWrapper
     /** @var string */
     public $fileSystemType;
 
-    /** @var integer */
+    /** @var int */
     public $cpuCount;
 
     /** @var string */
@@ -35,7 +35,7 @@ class EzcSystemInfoWrapper
     /** @var float */
     public $cpuSpeed;
 
-    /** @var integer */
+    /** @var int */
     public $memorySize;
 
     /** @var string */
@@ -57,7 +57,7 @@ class EzcSystemInfoWrapper
     {
         try {
             $ezcSystemInfo = ezcSystemInfo::getInstance();
-        } catch(ezcSystemInfoReaderCantScanOSException $e) {
+        } catch (ezcSystemInfoReaderCantScanOSException $e) {
             // Leave properties as null: https://github.com/zetacomponents/SystemInformation/pull/9
             return;
         }

--- a/SystemInfo/OutputFormat.php
+++ b/SystemInfo/OutputFormat.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzSupportToolsBundle\SystemInfo;
 interface OutputFormat
 {
     /**
-     * Format an array of collected information data, and return it as string
+     * Format an array of collected information data, and return it as string.
      *
      * @param array $collectedInfo
      * @return string

--- a/SystemInfo/OutputFormat/JsonOutputFormat.php
+++ b/SystemInfo/OutputFormat/JsonOutputFormat.php
@@ -17,6 +17,6 @@ class JsonOutputFormat implements SystemInfoOutputFormat
 {
     public function format(array $collectedInfo)
     {
-        return json_encode( $collectedInfo, JSON_PRETTY_PRINT);
+        return json_encode($collectedInfo, JSON_PRETTY_PRINT);
     }
 }

--- a/SystemInfo/OutputFormatRegistry.php
+++ b/SystemInfo/OutputFormatRegistry.php
@@ -41,7 +41,7 @@ class OutputFormatRegistry
             return $this->registry[$identifier];
         }
 
-        throw new NotFoundException("A SystemInfo output format could not be found.", $identifier);
+        throw new NotFoundException('A SystemInfo output format could not be found.', $identifier);
     }
 
     /**

--- a/SystemInfo/Registry/IdentifierBased.php
+++ b/SystemInfo/Registry/IdentifierBased.php
@@ -42,7 +42,7 @@ class IdentifierBased implements SystemInfoCollectorRegistry
             return $this->registry[$identifier];
         }
 
-        throw new NotFoundException("A SystemInfo collector could not be found.", $identifier);
+        throw new NotFoundException('A SystemInfo collector could not be found.', $identifier);
     }
 
     /**

--- a/Tests/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/DoctrineDatabaseSystemInfoCollectorTest.php
@@ -8,8 +8,6 @@
  */
 namespace EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\DoctrineDatabaseSystemInfoCollector;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\DatabaseSystemInfo;
 use PHPUnit_Framework_TestCase;

--- a/Tests/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
@@ -30,16 +30,19 @@ class EzcPhpSystemInfoCollectorTest extends PHPUnit_Framework_TestCase
             ->getMockBuilder('EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoWrapper')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->ezcSystemInfoMock->phpVersion = phpversion();
+        $this->ezcSystemInfoMock->phpVersion = PHP_VERSION;
 
         $this->ezcSystemInfoMock->phpAccelerator = $this
             ->getMockBuilder('ezcSystemInfoAccelerator')
-            ->setConstructorArgs([
-                'Zend OPcache',
-                'http://www.php.net/opcache',
-                true,
-                false,
-                '7.0.4-devFE'])
+            ->setConstructorArgs(
+                [
+                    'Zend OPcache',
+                    'http://www.php.net/opcache',
+                    true,
+                    false,
+                    '7.0.4-devFE',
+                ]
+            )
             ->getMock();
 
         $this->ezcPhpCollector = new EzcPhpSystemInfoCollector($this->ezcSystemInfoMock);

--- a/Tests/View/SystemInfoViewBuilderTest.php
+++ b/Tests/View/SystemInfoViewBuilderTest.php
@@ -4,8 +4,6 @@
  */
 namespace EzSystems\EzSupportToolsBundle\Tests\View;
 
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
-use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
 use EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder;
 
 class SystemInfoViewBuilderTest extends \PHPUnit_Framework_TestCase

--- a/View/SystemInfoViewBuilder.php
+++ b/View/SystemInfoViewBuilder.php
@@ -6,7 +6,6 @@ namespace EzSystems\EzSupportToolsBundle\View;
 
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
-use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector;
 use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
 
 class SystemInfoViewBuilder implements ViewBuilder

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "bin-dir": "bin"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "~2.7.1",
         "phpunit/phpunit": "^4.7"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.1",
         "phpunit/phpunit": "^4.7"
+    },
+    "scripts": {
+        "fix-cs": "@php ./bin/php-cs-fixer fix -v --show-progress=estimating"
     }
 }


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161)

This PR introduces `.php_cs` config and aligns CS.
To simplify fixing code it adds dev dependency on `php-cs-fixer` and introduces composer command:
```
composer fix-cs
```
which runs fixer on all files.

**TODO**:
- [x] Create php-cs-fixer config (`.php_cs`)
- [x] Add `php-cs-fixer` dev dependency to composer pointing to `~2.7.1`
- [x] Add composer command `fix-cs`
- [x] Fix CS
- [x] Travis: drop PHP 5.5 and add PHP 7.1 testing
- [x] Enable CS check on Travis (with disabled XDebug)