### PR TITLE
[WIP] Webpack Encore

### DIFF
--- a/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -11,10 +11,14 @@ namespace EzSystems\EzSupportToolsBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class EzSystemsEzSupportToolsExtension extends Extension
 {
+    const EZ_ENCORE_CONFIG_NAME = 'ez.config.js';
+
     /**
      * {@inheritdoc}
      */
@@ -23,5 +27,40 @@ class EzSystemsEzSupportToolsExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('default_settings.yml');
+
+        $this->dumpBundlesWebpackEncodeConfigurationPaths(
+            dirname($container->getParameter('kernel.root_dir')) . '/var/encore',
+            $container->getParameter('kernel.bundles_metadata')
+        );
+    }
+
+    /**
+     * Looks for Resources/encore/ez.config.js file in every registered and enabled bundle and dumps json list of paths to files found.
+     *
+     * @param string $targetPath Where to put eZ Encore paths configuration file (default: var/encore/ez.config.js)
+     * @param array $bundlesMetadata
+     */
+    public function dumpBundlesWebpackEncodeConfigurationPaths(string $targetPath, array $bundlesMetadata)
+    {
+        $finder = new Finder();
+        $filesystem = new Filesystem();
+
+        $paths = [];
+        
+        $finder
+            ->in(array_column($bundlesMetadata, 'path'))
+            ->path('Resources/encore')
+            ->name(self::EZ_ENCORE_CONFIG_NAME)
+            ->files();
+
+        foreach ($finder as $fileInfo) {
+            $paths[] = $fileInfo->getRealPath();
+        }
+
+        $filesystem->mkdir($targetPath);
+        $filesystem->dumpFile(
+            $targetPath . '/' . self::EZ_ENCORE_CONFIG_NAME,
+            sprintf('module.exports = %s', json_encode($paths))
+        );
     }
 }


### PR DESCRIPTION
Follow up to: https://github.com/ezsystems/ezplatform/pull/345

Looks for webpack encore configuration per bundle in `Resources/encore/ez.config.js` directory.

Dumps list (JSON format) of path to files to `var/encore/ez.config.js` to be used by main feature.

Makes this part of main feature obsolete:

> It goes thru all bundles in vendor/ezsystems and looking for ez.webpack.config.js if found it register the config.