### PR TITLE
Updated install_ee doc link

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,7 +22,7 @@ parameters:
         training_service: "https://ez.no/Services/Training"
         consulting_service: "https://ez.no/Services/Consulting"
         ee_product: "https://ez.no/Products/eZ-Platform-Enterprise-Edition"
-        install_ee: "https://doc.ezplatform.com/en/#{ez.release}/getting_started/install_ez_enterprise/"
+        install_ee: "https://doc.ezplatform.com/en/{ez.release}/getting_started/install_ez_enterprise/"
         doc: "https://doc.ezplatform.com"
         update: "https://doc.ezplatform.com/en/latest/releases/updating_ez_platform/"
         gpl_faq: "https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.en.html#GPLModuleLicense"


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30262

The generated link has form:
https://doc.ezplatform.com/en/#2.5/getting_started/install_ez_enterprise/
but all our current doc links do not have the hashtag, for example:
https://doc.ezplatform.com/en/2.4/getting_started/install_ez_enterprise/
https://doc.ezplatform.com/en/2.3/getting_started/install_ez_enterprise/

2.5 doc will also be published without the `#`.