### PR TITLE
Use correct key for update url

### DIFF
--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -55,7 +55,7 @@
             {# In the future with retrival of info from updates.ez.no we can detect missing (public) security fixes and then let this become an error #}
             {% set severity = 1 %}
             <div class="alert alert-warning mb-0 mt-3" role="alert">
-                {{ 'dashboard.ez_version.community_end_of_maintenance'|trans({'%release%': ez.release, '%update_url%': urls['update_url']})
+                {{ 'dashboard.ez_version.community_end_of_maintenance'|trans({'%release%': ez.release, '%update_url%': urls['update']})
                 |desc("Unfortunately %release% open source version has reached end of life, <a target=\"_blank\" href=\"%update_url%\">please upgrade</a>.")}}
                 <em>
                     {{ 'dashboard.ez_version.community_end_of_maintenance_upgrade'|trans({


### PR DESCRIPTION
The URL is defined as `update`in https://github.com/ezsystems/ez-support-tools/blob/1.0/Resources/config/services.yml#L27

This problem occurred on current master in https://github.com/ezsystems/ezplatform/pull/397 in tests, when browsing the Dashboard:

https://res.cloudinary.com/ezplatformtravis/image/upload/v1556274925/screenshots/5cc2deed9682e714913640-vendor_ezsystems_ezplatform-admin-ui_features_objectstates_feature_11_zzymim.png