### PR TITLE
EZP-30402: Make Dashboard code more solid when it comes to detecting trial or not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ cache:
 matrix:
     fast_finish: true
     include:
-        - php: 5.6
-        - php: 7.0
         - php: 7.1
           env: CHECK_CS=true
         - php: 7.2

--- a/AdminUi/Component/EzInfoTwigComponent.php
+++ b/AdminUi/Component/EzInfoTwigComponent.php
@@ -73,7 +73,7 @@ class EzInfoTwigComponent implements Renderable
         $urls = $this->urlList;
         foreach ($this->urlList as $urlName => $url) {
             foreach ($this->ezSystemInfo as $attribute => $value) {
-                if (is_string($value) && strpos($url,'{ez.' . $attribute . '}') !== false) {
+                if (\is_string($value) && strpos($url, '{ez.' . $attribute . '}') !== false) {
                     $urls[$urlName] = str_replace('{ez.' . $attribute . '}', $value, $url);
                 }
             }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -55,13 +55,14 @@ services:
             - "@support_tools.system_info.collector.composer.lock_file"
             - "%kernel.debug%"
         # Can't tag this before v0.3 (2.5?) as it will blow up in admin UI for missing templates there
-        # And it does not look like there is anway to add it from this package, so maybe it needs to be made extensible(?)
+        # And it does not look like there is anyway to add it from this package, so maybe it needs to be made extensible(?)
         #tags: [{ name: "support_tools.system_info.collector", identifier: "ez" }]
 
     support_tools.system_info.collector.composer.lock_file:
         class: "%support_tools.system_info.collector.composer.lock_file.class%"
         arguments:
             - "%kernel.root_dir%/../composer.lock"
+            - "%kernel.root_dir%/../composer.json"
         tags:
             - { name: "support_tools.system_info.collector", identifier: "composer" }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -55,7 +55,7 @@ services:
             - "@support_tools.system_info.collector.composer.lock_file"
             - "%kernel.debug%"
         # Can't tag this before v0.3 (2.5?) as it will blow up in admin UI for missing templates there
-        # And it does not look like there is anyway to add it from this package, so maybe it needs to be made extensible(?)
+        # And it does not look like there is any way to add it from this package, so maybe it needs to be made extensible(?)
         #tags: [{ name: "support_tools.system_info.collector", identifier: "ez" }]
 
     support_tools.system_info.collector.composer.lock_file:

--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -11,7 +11,7 @@
 {% set levels = {0: "info", 1: "warning", 2: "danger"} %}
 {% set icons = {0: "", 1: "&#9888;", 2: "&#9888;"} %}
 {% set status %}
-    {% spaceless %}
+{% spaceless %}
     {% if not ez.release %}
         {% set severity = 1 %}
         <div class="alert alert-warning mb-0 mt-3" role="alert">

--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -148,7 +148,7 @@ class EzSystemInfoCollector implements SystemInfoCollector
 
         // In case someone switches from TTL to BUL, make sure we only identify install as Trial if this is present,
         // as well as TTL packages
-        $hasTTLComposerRepo = in_array('https://updates.ez.no/ttl', $this->composerInfo->repositoryUrls);
+        $hasTTLComposerRepo = \in_array('https://updates.ez.no/ttl', $this->composerInfo->repositoryUrls);
 
         if ($package = $this->getFirstPackage(self::ENTERPISE_PACKAGES)) {
             $ez->isEnterpise = true;

--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -146,15 +146,19 @@ class EzSystemInfoCollector implements SystemInfoCollector
             $ez->release = (string)(((float)$this->composerInfo->packages['ezsystems/ezpublish-kernel']->version) - 5);
         }
 
+        // In case someone switches from TTL to BUL, make sure we only identify install as Trial if this is present,
+        // as well as TTL packages
+        $hasTTLComposerRepo = in_array('https://updates.ez.no/ttl', $this->composerInfo->repositoryUrls);
+
         if ($package = $this->getFirstPackage(self::ENTERPISE_PACKAGES)) {
             $ez->isEnterpise = true;
-            $ez->isTrial = $package->license === 'TTL-2.0';
+            $ez->isTrial = $hasTTLComposerRepo && $package->license === 'TTL-2.0';
             $ez->name = 'eZ Platform Enterprise';
         }
 
         if ($package = $this->getFirstPackage(self::COMMERCE_PACKAGES)) {
             $ez->isCommerce = true;
-            $ez->isTrial = $ez->isTrial || $package->license === 'TTL-2.0';
+            $ez->isTrial = $ez->isTrial || $hasTTLComposerRepo && $package->license === 'TTL-2.0';
             $ez->name = 'eZ Commerce';
         }
 

--- a/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
+++ b/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
@@ -84,9 +84,9 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
     /**
      * @param array $lockData
      *
-     * @return array
+     * @return \EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerPackage[]
      */
-    private function extractPackages(array $lockData)
+    private function extractPackages(array $lockData): array
     {
         $packages = [];
         $rootAliases = [];
@@ -128,7 +128,12 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
         return $packages;
     }
 
-    private function extractRepositoryUrls(array $jsonData)
+    /**
+     * @param array $jsonData
+     *
+     * @return string[]
+     */
+    private function extractRepositoryUrls(array $jsonData): array
     {
         $repos = [];
         foreach ($jsonData['repositories'] as $composerRepository) {
@@ -146,7 +151,10 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
         return $repos;
     }
 
-    private static function setNormalizedVersion(Value\ComposerPackage $package)
+    /**
+     * @param Value\ComposerPackage $package
+     */
+    private static function setNormalizedVersion(Value\ComposerPackage $package): void
     {
         $version = $package->alias ? $package->alias : $package->branch;
         if ($version[0] === 'v') {

--- a/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
+++ b/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
@@ -35,13 +35,19 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
     private $lockFile;
 
     /**
+     * @var string Composer json file with full path.
+     */
+    private $jsonFile;
+
+    /**
      * @var Value\ComposerSystemInfo The collected value, cached in case info is collected by other collectors.
      */
     private $value;
 
-    public function __construct($lockFile)
+    public function __construct($lockFile, $jsonFile)
     {
         $this->lockFile = $lockFile;
+        $this->jsonFile = $jsonFile;
     }
 
     /**
@@ -61,15 +67,33 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
             throw new Exception\ComposerLockFileNotFoundException($this->lockFile);
         }
 
+        if (!file_exists($this->jsonFile)) {
+            throw new Exception\ComposerJsonFileNotFoundException($this->jsonFile);
+        }
+
+        $lockData = json_decode(file_get_contents($this->lockFile), true);
+        $jsonData = json_decode(file_get_contents($this->jsonFile), true);
+
+        return $this->value = new Value\ComposerSystemInfo([
+            'packages' => $this->extractPackages($lockData),
+            'repositoryUrls' => $this->extractRepositoryUrls($jsonData),
+            'minimumStability' => isset($lockData['minimum-stability']) ? $lockData['minimum-stability'] : null,
+        ]);
+    }
+
+    /**
+     * @param array $lockData
+     *
+     * @return array
+     */
+    private function extractPackages(array $lockData)
+    {
         $packages = [];
         $rootAliases = [];
-        $lockData = json_decode(file_get_contents($this->lockFile), true);
         foreach ($lockData['aliases'] as $alias) {
             $rootAliases[$alias['package']] = $alias['alias'];
         }
 
-        // For PHP 5.6, add variable locally to be able to use isset() on it.
-        $stabilities = self::STABILITIES;
         foreach ($lockData['packages'] as $packageData) {
             $package = new Value\ComposerPackage([
                 'name' => $packageData['name'],
@@ -83,8 +107,8 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
             if (isset($lockData['stability-flags'][$package->name])) {
                 $stabilityFlag = (int)$lockData['stability-flags'][$package->name];
 
-                if (isset($stabilities[$stabilityFlag])) {
-                    $package->stability = $stabilities[$stabilityFlag];
+                if (isset(self::STABILITIES[$stabilityFlag])) {
+                    $package->stability = self::STABILITIES[$stabilityFlag];
                 }
             }
 
@@ -101,10 +125,26 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
 
         ksort($packages, SORT_FLAG_CASE | SORT_STRING);
 
-        return $this->value = new Value\ComposerSystemInfo([
-            'packages' => $packages,
-            'minimumStability' => isset($lockData['minimum-stability']) ? $lockData['minimum-stability'] : null,
-        ]);
+        return $packages;
+    }
+
+
+    private function extractRepositoryUrls(array $jsonData)
+    {
+        $repos = [];
+        foreach ($jsonData['repositories'] as $composerRepository) {
+            if (empty($composerRepository['type']) || $composerRepository['type'] !== 'composer') {
+                continue;
+            }
+
+            if (empty($composerRepository['url'])) {
+                continue;
+            }
+
+            $repos[] = $composerRepository['url'];
+        }
+
+        return $repos;
     }
 
     private static function setNormalizedVersion(Value\ComposerPackage $package)

--- a/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
+++ b/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
@@ -128,7 +128,6 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
         return $packages;
     }
 
-
     private function extractRepositoryUrls(array $jsonData)
     {
         $repos = [];

--- a/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
+++ b/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * File containing the ComposerLockFileNotFoundException class.
+ * File containing the ComposerJsonFileNotFoundException class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -11,10 +11,10 @@ namespace EzSystems\EzSupportToolsBundle\SystemInfo\Exception;
 use Exception;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException as BaseNotFoundException;
 
-class ComposerLockFileNotFoundException extends BaseNotFoundException
+class ComposerJsonFileNotFoundException extends BaseNotFoundException
 {
     public function __construct($path, Exception $previous = null)
     {
-        parent::__construct('Composer.lock file', $path, $previous);
+        parent::__construct('Composer.json file', $path, $previous);
     }
 }

--- a/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
+++ b/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException as BaseNotFoundException;
 
 class ComposerJsonFileNotFoundException extends BaseNotFoundException
 {
-    public function __construct($path, Exception $previous = null)
+    public function __construct(string $path, Exception $previous = null)
     {
         parent::__construct('Composer.json file', $path, $previous);
     }

--- a/SystemInfo/Exception/ComposerLockFileNotFoundException.php
+++ b/SystemInfo/Exception/ComposerLockFileNotFoundException.php
@@ -15,6 +15,6 @@ class ComposerLockFileNotFoundException extends BaseNotFoundException
 {
     public function __construct($path, Exception $previous = null)
     {
-        parent::__construct('Composer.lock file', $path, $previous);
+        parent::__construct('composer.lock file', $path, $previous);
     }
 }

--- a/SystemInfo/Value/ComposerSystemInfo.php
+++ b/SystemInfo/Value/ComposerSystemInfo.php
@@ -38,7 +38,7 @@ class ComposerSystemInfo extends ValueObject implements SystemInfo
      *
      * Will contain urls used so would be possible to know if bul or ttl packages are used for instance.
      *
-     * @var array
+     * @var string[]
      */
     public $repositoryUrls = [];
 }

--- a/SystemInfo/Value/ComposerSystemInfo.php
+++ b/SystemInfo/Value/ComposerSystemInfo.php
@@ -32,4 +32,13 @@ class ComposerSystemInfo extends ValueObject implements SystemInfo
      * @var string|null
      */
     public $minimumStability;
+
+    /**
+     * Additional Composer repository urls used.
+     *
+     * Will contain urls used so would be possible to know if bul or ttl packages are used for instance.
+     *
+     * @var array
+     */
+    public $repositoryUrls = [];
 }

--- a/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -65,14 +65,13 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
                 ]),
             ],
             'minimumStability' => 'stable',
+            'repositoryUrls' => ['https://updates.ez.no/bul'],
         ]);
 
-        $composerCollector = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock');
-
+        $composerCollector = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/composer.json');
         $value = $composerCollector->collect();
 
         self::assertInstanceOf('EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo', $value);
-
         self::assertEquals($expected, $value);
     }
 
@@ -81,10 +80,20 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
      *
      * @expectedException \EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException
      */
-    public function testCollectFileNotFound()
+    public function testCollectLockFileNotFound()
     {
-        $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/snafu.lock');
+        $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/snafu.lock', __DIR__ . '/_fixtures/composer.json');
+        $composerCollectorNotFound->collect();
+    }
 
+    /**
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
+     *
+     * @expectedException \EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerJsonFileNotFoundException
+     */
+    public function testCollectJsonFileNotFound()
+    {
+        $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/snafu.json');
         $composerCollectorNotFound->collect();
     }
 }

--- a/Tests/SystemInfo/Collector/_fixtures/composer.json
+++ b/Tests/SystemInfo/Collector/_fixtures/composer.json
@@ -1,0 +1,147 @@
+{
+    "name": "ezsystems/ezplatform-ee",
+    "description": "eZ Platform Enterprise Edition distribution",
+    "homepage": "https://github.com/ezsystems/ezplatform-ee",
+    "license": "proprietary",
+    "type": "project",
+    "authors": [
+        {
+            "name": "eZ dev-team & eZ Community",
+            "homepage": "https://github.com/ezsystems/ezplatform-ee/contributors"
+        }
+    ],
+    "repositories": [
+        { "type": "composer", "url": "https://updates.ez.no/bul" }
+    ],
+    "replace": {
+        "ezsystems/ezstudio": "*",
+        "ezsystems/ezpublish-community": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "AppBundle\\": "src/AppBundle/"
+        },
+        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
+    },
+    "autoload-dev": {
+        "psr-4": { "Tests\\": "tests/" },
+        "files": [ "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
+    },
+    "require": {
+        "php": "^7.1.3",
+        "doctrine/doctrine-bundle": "^1.9.1",
+        "doctrine/orm": "^2.6.3",
+        "ezsystems/date-based-publisher": "^3.2",
+        "ezsystems/doctrine-dbal-schema": "^0.1",
+        "ezsystems/ez-support-tools": "^1.0",
+        "ezsystems/ezplatform-admin-ui": "^1.5",
+        "ezsystems/ezplatform-admin-ui-assets": "^4.1.0",
+        "ezsystems/ezplatform-admin-ui-modules": "^1.5",
+        "ezsystems/ezplatform-core": "^1.0",
+        "ezsystems/ezplatform-cron": "^2.0",
+        "ezsystems/ezplatform-design-engine": "^2.0",
+        "ezsystems/ezplatform-ee-installer": "^2.5",
+        "ezsystems/ezplatform-form-builder": "^1.2",
+        "ezsystems/ezplatform-graphql": "^1.0",
+        "ezsystems/ezplatform-http-cache": "^0.9",
+        "ezsystems/ezplatform-http-cache-fastly": "^1.1",
+        "ezsystems/ezplatform-matrix-fieldtype": "^1.0",
+        "ezsystems/ezplatform-page-builder": "^1.3",
+        "ezsystems/ezplatform-page-fieldtype": "^1.3",
+        "ezsystems/ezplatform-richtext": "^1.1",
+        "ezsystems/ezplatform-solr-search-engine": "^1.6",
+        "ezsystems/ezplatform-standard-design": "^0.2",
+        "ezsystems/ezplatform-user": "^1.0",
+        "ezsystems/ezplatform-workflow": "^1.1",
+        "ezsystems/ezpublish-kernel": "^7.5",
+        "ezsystems/flex-workflow": "^3.2",
+        "ezsystems/repository-forms": "^2.5",
+        "ezsystems/symfony-tools": "~1.0.0",
+        "friendsofsymfony/jsrouting-bundle": "^1.6.3",
+        "gregwar/captcha-bundle": "^2.0",
+        "incenteev/composer-parameter-handler": "^2.1.3",
+        "knplabs/knp-menu-bundle": "^2.2.1",
+        "leafo/scssphp": "^0.7.7",
+        "overblog/graphql-bundle": "^0.11.11",
+        "sensio/distribution-bundle": "^5.0.23",
+        "sensiolabs/security-checker": "^5.0",
+        "symfony/assetic-bundle": "^2.8.2",
+        "symfony/monolog-bundle": "^3.3.1",
+        "symfony/swiftmailer-bundle": "^3.2.4",
+        "symfony/symfony": "^3.4.18",
+        "symfony/thanks": "^1.1.0",
+        "symfony/webpack-encore-bundle": "^1.0.0",
+        "twig/extensions": "^1.5.3",
+        "twig/twig": "^2.5",
+        "white-october/pagerfanta-bundle": "^1.2.2",
+        "willdurand/js-translation-bundle": "^2.6.6"
+    },
+    "require-dev": {
+        "behat/behat": "^3.5.0",
+        "behat/mink-extension": "^2.3.1",
+        "behat/mink-goutte-driver": "^1.2.1",
+        "behat/mink-selenium2-driver": "^1.3.1",
+        "behat/symfony2-extension": "^2.1.5",
+        "bex/behat-screenshot": "^1.2.7",
+        "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1.0",
+        "ezsystems/behatbundle": "^6.5.4",
+        "overblog/graphiql-bundle": "^0.1.2",
+        "phpunit/phpunit": "^6.5.13",
+        "sensio/generator-bundle": "^3.1.7",
+        "symfony/phpunit-bridge": "^3.4.18",
+        "liuggio/fastest": "^1.6"
+    },
+    "conflict": {
+        "symfony/symfony": "3.4.9||3.4.12||3.4.16",
+        "doctrine/dbal": "2.7.0",
+        "twig/twig": "2.6.1",
+        "symfony/webpack-encore-bundle": "1.2.0||1.2.1"
+    },
+    "scripts": {
+        "symfony-scripts": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
+            "@php bin/console bazinga:js-translation:dump web/assets --merge-domains",
+            "@php bin/console assetic:dump",
+            "yarn install",
+            "EzSystems\\EzPlatformEncoreBundle\\Composer\\ScriptHandler::compileAssets",
+            "@php bin/security-checker security:check"
+        ],
+        "post-install-cmd": [
+            "@symfony-scripts"
+        ],
+        "post-update-cmd": [
+            "@symfony-scripts"
+        ],
+        "post-create-project-cmd": [
+            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::installWelcomeText"
+        ],
+        "ezplatform-install": [
+            "@php bin/console ezplatform:install ezplatform-ee-clean"
+        ]
+    },
+    "config": {
+        "bin-dir": "bin",
+        "sort-packages": true,
+        "preferred-install": {
+            "ezsystems/*": "dist"
+        }
+    },
+    "extra": {
+        "symfony-app-dir": "app",
+        "symfony-bin-dir": "bin",
+        "symfony-var-dir": "var",
+        "symfony-web-dir": "web",
+        "symfony-tests-dir": "tests",
+        "symfony-assets-install": "relative",
+        "incenteev-parameters": {
+            "keep-outdated": true,
+            "file": "app/config/parameters.yml"
+        },
+        "branch-alias": {
+            "dev-master": "2.5.x-dev"
+        }
+    }
+}


### PR DESCRIPTION
Adds logic to also read info from composer.json to detect if packages are pulled from ttl channel
or not.

Besides the current issues with updates.ez.no telling composer the packages are ttl when they are not (diff between packages.json and composer.json). This also solves issues when people switch from TTL to BUL, and install won't show they have switched until all TTL packages actually have a new release to pull in.