### PR TITLE
EZP-30814: Removed Twig deprecations

### DIFF
--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -11,7 +11,7 @@
 {% set levels = {0: "info", 1: "warning", 2: "danger"} %}
 {% set icons = {0: "", 1: "&#9888;", 2: "&#9888;"} %}
 {% set status %}
-{% spaceless %}
+{% apply spaceless %}
     {% if not ez.release %}
         {% set severity = 1 %}
         <div class="alert alert-warning mb-0 mt-3" role="alert">
@@ -117,7 +117,7 @@
             {% endif %}
         </div>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endset %}
 
 <div class="mb-4">


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30814

## Description

Continuation of https://github.com/ezsystems/ezpublish-kernel/pull/2708: replaced `spaceless` tag usages in favour of `spaceless` filter