### PR TITLE
Improve dev message on dashboard, and always show when in dev

### DIFF
--- a/Resources/translations/dashboard.en.xlf
+++ b/Resources/translations/dashboard.en.xlf
@@ -57,10 +57,15 @@
                     and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure your project.]]></target>
         <note>key: dashboard.ez_version.end_of_maintenance_contanct</note>
       </trans-unit>
-      <trans-unit id="99cfacc8eb18b57ad83dccc62b053ad0aea20b79" resname="dashboard.ez_version.non_stable">
-        <source>Your setup is running with unstable packages, this is not recommended besides when testing updates.</source>
-        <target state="new">Your setup is running with unstable packages, this is not recommended besides when testing updates.</target>
-        <note>key: dashboard.ez_version.non_stable</note>
+      <trans-unit id="99cfacc8eb18b57ad83dccc62b053ad0aea20b79" resname="dashboard.ez_version.non_stable_packages">
+        <source>Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.</source>
+        <target state="new">Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.</target>
+        <note>key: dashboard.ez_version.non_stable_packages</note>
+      </trans-unit>
+      <trans-unit id="6a0387251f6e862fedb59341ccc65722f169438a" resname="dashboard.ez_version.unstable_minimum_stability">
+        <source>Your setup is running with '%minimum_stability%' as composer.json minimumStability, this is not recommended besides when testing updates or during development.</source>
+        <target state="new">Your setup is running with '%minimum_stability%' as composer.json minimumStability, this is not recommended besides when testing updates or during development.</target>
+        <note>key: dashboard.ez_version.unstable_minimum_stability</note>
       </trans-unit>
       <trans-unit id="59967d79ef1f521fd483dbb057f15bc756b80423" resname="dashboard.ez_version.non_stable_ee">
         <source><![CDATA[If you need assistance, don't hesitate to <a target="_blank" href="%support_url%">get in touch with eZ support</a>.]]></source>

--- a/Resources/translations/dashboard.en.xlf
+++ b/Resources/translations/dashboard.en.xlf
@@ -45,17 +45,17 @@
                 please plan to upgrade. If you need assistance, don't hesitate to <a target="_blank" href="%contact_url%">contact eZ</a>.]]></target>
         <note>key: dashboard.ez_version.end_of_life_upgrade</note>
       </trans-unit>
-      <trans-unit id="d620cc5d1f36ef74cbf6c042e07c0ad89bf47d9f" resname="dashboard.ez_version.end_of_maintenance">
+      <trans-unit id="d620cc5d1f36ef74cbf6c042e07c0ad89bf47d9f" resname="dashboard.ez_version.trial_end_of_maintenance">
         <source>Your trial period is coming to an end.</source>
         <target state="new">Your trial period is coming to an end.</target>
-        <note>key: dashboard.ez_version.end_of_maintenance</note>
+        <note>key: dashboard.ez_version.trial_end_of_maintenance</note>
       </trans-unit>
-      <trans-unit id="7b47468c70176c3f6c78ca0e29b1378e2685d2e1" resname="dashboard.ez_version.end_of_maintenance_contanct">
+      <trans-unit id="7b47468c70176c3f6c78ca0e29b1378e2685d2e1" resname="dashboard.ez_version.trial_contact">
         <source><![CDATA[<a target="_blank" href="%contact_url%">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure your project.]]></source>
+                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure composer.json 'repositories' url for 'bul' instead of 'ttl'.]]></source>
         <target state="new"><![CDATA[<a target="_blank" href="%contact_url%">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure your project.]]></target>
-        <note>key: dashboard.ez_version.end_of_maintenance_contanct</note>
+                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure composer.json 'repositories' url for 'bul' instead of 'ttl'.]]></target>
+        <note>key: dashboard.ez_version.trial_contact</note>
       </trans-unit>
       <trans-unit id="99cfacc8eb18b57ad83dccc62b053ad0aea20b79" resname="dashboard.ez_version.non_stable_packages">
         <source>Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.</source>
@@ -79,31 +79,17 @@
             your eZ install, and recommended to be kept on project development to make sure same package versions are used across all environments.]]></target>
         <note>key: dashboard.ez_version.release_not_determined</note>
       </trans-unit>
-      <trans-unit id="b0b5f4a2312f9a25f310e6d5044046ce0146a9c3" resname="dashboard.ez_version.severity_non">
+      <trans-unit id="b0b5f4a2312f9a25f310e6d5044046ce0146a9c3" resname="dashboard.ez_version.trial_notice">
         <source><![CDATA[Welcome to %name%, check our <a target="_blank" href="%doc_url%">online documentation</a>, <a target="_blank" href="%consulting_url%">consulting</a>
                     or <a target="_blank" href="%training_url%">training</a> services in order to get the most out of your trial.]]></source>
         <target state="new"><![CDATA[Welcome to %name%, check our <a target="_blank" href="%doc_url%">online documentation</a>, <a target="_blank" href="%consulting_url%">consulting</a>
                     or <a target="_blank" href="%training_url%">training</a> services in order to get the most out of your trial.]]></target>
-        <note>key: dashboard.ez_version.severity_non</note>
-      </trans-unit>
-      <trans-unit id="977ad02930ea5e0ae86eab268d0628786ad6b909" resname="dashboard.ez_version.severity_non_contant">
-        <source><![CDATA[<a target="_blank" href="%contact_url%">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure your project.]]></source>
-        <target state="new"><![CDATA[<a target="_blank" href="%contact_url%">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure your project.]]></target>
-        <note>key: dashboard.ez_version.severity_non_contant</note>
+        <note>key: dashboard.ez_version.trial_notice</note>
       </trans-unit>
       <trans-unit id="10afa9a6e250d82f948ea1e6cbcdf7aac8bd7a4b" resname="dashboard.ez_version.trial_expired">
         <source><![CDATA[Unfortunately your trial period has expired and your <a target="_blank" href="%ttl_url%">TTL license</a> is no longer valid.]]></source>
         <target state="new"><![CDATA[Unfortunately your trial period has expired and your <a target="_blank" href="%ttl_url%">TTL license</a> is no longer valid.]]></target>
         <note>key: dashboard.ez_version.trial_expired</note>
-      </trans-unit>
-      <trans-unit id="fad8721d93ef0b882327327f52921f656a8e206b" resname="dashboard.ez_version.trial_expired_contant">
-        <source><![CDATA[<a target="_blank" href="%contact_url%">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure your project.]]></source>
-        <target state="new"><![CDATA[<a target="_blank" href="%contact_url%">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure your project.]]></target>
-        <note>key: dashboard.ez_version.trial_expired_contant</note>
       </trans-unit>
     </body>
   </file>

--- a/Resources/translations/dashboard.en.xlf
+++ b/Resources/translations/dashboard.en.xlf
@@ -58,13 +58,13 @@
         <note>key: dashboard.ez_version.trial_contact</note>
       </trans-unit>
       <trans-unit id="99cfacc8eb18b57ad83dccc62b053ad0aea20b79" resname="dashboard.ez_version.non_stable_packages">
-        <source>Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.</source>
-        <target state="new">Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.</target>
+        <source>Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.</source>
+        <target state="new">Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.</target>
         <note>key: dashboard.ez_version.non_stable_packages</note>
       </trans-unit>
       <trans-unit id="6a0387251f6e862fedb59341ccc65722f169438a" resname="dashboard.ez_version.unstable_minimum_stability">
-        <source>Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.</source>
-        <target state="new">Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.</target>
+        <source>Your setup is running with '%minimum_stability%' as composer.json minimum-stability. This is not recommended except when testing updates or during development.</source>
+        <target state="new">Your setup is running with '%minimum_stability%' as composer.json minimum-stability. This is not recommended except when testing updates or during development.</target>
         <note>key: dashboard.ez_version.unstable_minimum_stability</note>
       </trans-unit>
       <trans-unit id="59967d79ef1f521fd483dbb057f15bc756b80423" resname="dashboard.ez_version.non_stable_ee">

--- a/Resources/translations/dashboard.en.xlf
+++ b/Resources/translations/dashboard.en.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="6a0387251f6e862fedb59341ccc65722f169438a" resname="dashboard.ez_version.unstable_minimum_stability">
         <source>Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.</source>
-        <target state="new">Your setup is running with '%minimum_stability%' as composer.json minimumStability, this is not recommended besides when testing updates or during development.</target>
+        <target state="new">Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.</target>
         <note>key: dashboard.ez_version.unstable_minimum_stability</note>
       </trans-unit>
       <trans-unit id="59967d79ef1f521fd483dbb057f15bc756b80423" resname="dashboard.ez_version.non_stable_ee">

--- a/Resources/translations/dashboard.en.xlf
+++ b/Resources/translations/dashboard.en.xlf
@@ -63,7 +63,7 @@
         <note>key: dashboard.ez_version.non_stable_packages</note>
       </trans-unit>
       <trans-unit id="6a0387251f6e862fedb59341ccc65722f169438a" resname="dashboard.ez_version.unstable_minimum_stability">
-        <source>Your setup is running with '%minimum_stability%' as composer.json minimumStability, this is not recommended besides when testing updates or during development.</source>
+        <source>Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.</source>
         <target state="new">Your setup is running with '%minimum_stability%' as composer.json minimumStability, this is not recommended besides when testing updates or during development.</target>
         <note>key: dashboard.ez_version.unstable_minimum_stability</note>
       </trans-unit>

--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -18,6 +18,19 @@
             {{ 'dashboard.ez_version.release_not_determined'|trans|desc("The system could not find your <code>composer.lock</code> file. It's needed to determine information about
             your eZ install, and recommended to be kept on project development to make sure same package versions are used across all environments.")}}
         </div>
+    {% elseif ez.stability != 'stable'  %}
+        {% set severity = 1 %}
+        {% set badge = 'Development' %}
+        <div class="alert alert-warning mb-0 mt-3" role="alert">
+            {% if ez.composerInfo.minimumStability != 'stable' %}
+                {{ 'dashboard.ez_version.unstable_minimum_stability'|trans({'%minimum_stability%': ez.composerInfo.minimumStability})|desc("Your setup is running with '%minimum_stability%' as composer.json minimumStability, this is not recommended besides when testing updates or during development.") }}
+            {% else  %}
+                {{ 'dashboard.ez_version.non_stable_packages'|trans({'%stability%': ez.stability})|desc("Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.") }}
+            {% endif %}
+            {% if ez.isEnterpise %}
+                {{ 'dashboard.ez_version.non_stable_ee'|trans({'%support_url%': urls['support']})|desc("If you need assistance, don't hesitate to <a target=\"_blank\" href=\"%support_url%\">get in touch with eZ support</a>.")|raw }}
+            {% endif %}
+        </div>
     {% elseif ez.isTrial %}
         {% set badge = 'Trial' %}
         {% if ez.isEndOfLife %}
@@ -106,15 +119,6 @@
             |desc("Unfortunately %release% has reached <a target=\"_blank\" href=\"%service_life_url%\">end of life</a>,
                 please plan to upgrade. If you need assistance, don't hesitate to <a target=\"_blank\" href=\"%contact_url%\">contact eZ</a>.")
             |raw }}
-        </div>
-    {% elseif not ez.debug and ez.stability != 'stable'  %}
-        {% set severity = 1 %}
-        {% set badge = 'Development' %}
-        <div class="alert alert-warning mb-0 mt-3" role="alert">
-            {{ 'dashboard.ez_version.non_stable'|trans|desc("Your setup is running with unstable packages, this is not recommended besides when testing updates.") }}
-            {% if ez.isEnterpise %}
-                {{ 'dashboard.ez_version.non_stable_ee'|trans({'%support_url%': urls['support']})|desc("If you need assistance, don't hesitate to <a target=\"_blank\" href=\"%support_url%\">get in touch with eZ support</a>.")|raw }}
-            {% endif %}
         </div>
     {% endif %}
 {% endapply %}

--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -37,31 +37,23 @@
             {% set severity = 2 %}
             <div class="alert alert-danger mb-0 mt-3" role="alert">
                 {{ 'dashboard.ez_version.trial_expired'|trans({'%ttl_url%': urls['ttl']})|desc("Unfortunately your trial period has expired and your <a target=\"_blank\" href=\"%ttl_url%\">TTL license</a> is no longer valid.")|raw }}
-                {{ 'dashboard.ez_version.trial_expired_contant'|trans({'%contact_url%': urls['contact'], '%install_ee%': urls['install_ee']})|desc("<a target=\"_blank\" href=\"%contact_url%\">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target=\"_blank\" href=\"%install_ee%\">online documentation</a> to configure your project.")|raw }}
-            </div>
         {% elseif ez.isEndOfMaintenance %}
             {% set severity = 1 %}
             <div class="alert alert-warning mb-0 mt-3" role="alert">
-                {{ 'dashboard.ez_version.end_of_maintenance'|trans|desc("Your trial period is coming to an end.")}}
-                {{ 'dashboard.ez_version.end_of_maintenance_contanct'|trans({'%contact_url%': urls['contact'], '%install_ee%': urls['install_ee']})
-                |desc("<a target=\"_blank\" href=\"%contact_url%\">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target=\"_blank\" href=\"%install_ee%\">online documentation</a> to configure your project.")
-                |raw }}
-            </div>
+                {{ 'dashboard.ez_version.trial_end_of_maintenance'|trans|desc("Your trial period is coming to an end.")}}
         {% else %}
             {% set severity = 0 %}
             <div class="alert alert-info mb-0 mt-3" role="alert">
-                {{ 'dashboard.ez_version.severity_non'|trans({'%name%': ez.name, '%doc_url%': urls['doc'], '%consulting_url%': urls['consulting_service'], '%training_url%': urls['training_service']})
+                {{ 'dashboard.ez_version.trial_notice'|trans({'%name%': ez.name, '%doc_url%': urls['doc'], '%consulting_url%': urls['consulting_service'], '%training_url%': urls['training_service']})
                 |desc('Welcome to %name%, check our <a target=\"_blank\" href=\"%doc_url%\">online documentation</a>, <a target=\"_blank\" href=\"%consulting_url%\">consulting</a>
                     or <a target=\"_blank\" href=\"%training_url%\">training</a> services in order to get the most out of your trial.')
                 |raw }}
-                {{ 'dashboard.ez_version.severity_non_contant'|trans({'%contact_url%': urls['contact'], '%install_ee%': urls['install_ee']})
-                |desc("<a target=\"_blank\" href=\"%contact_url%\">Contact eZ or its partner(s)</a> to purchase a subscription
-                    and follow the <a target=\"_blank\" href=\"%install_ee%\">online documentation</a> to configure your project.")
-                |raw }}
-            </div>
         {% endif %}
+            {{ 'dashboard.ez_version.trial_contact'|trans({'%contact_url%': urls['contact'], '%install_ee%': urls['install_ee']})
+            |desc("<a target=\"_blank\" href=\"%contact_url%\">Contact eZ or its partner(s)</a> to purchase a subscription
+                and follow the <a target=\"_blank\" href=\"%install_ee%\">online documentation</a> to configure composer.json 'repositories' url for 'bul' instead of 'ttl'.")
+            |raw }}
+        </div>
     {% elseif not ez.isEnterpise %}
         {% set badge = 'GPL' %}
         {% if ez.isEndOfMaintenance %}

--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -25,7 +25,7 @@
             {% if ez.composerInfo.minimumStability != 'stable' %}
                 {{ 'dashboard.ez_version.unstable_minimum_stability'|trans({'%minimum_stability%': ez.composerInfo.minimumStability})|desc("Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.") }}
             {% else  %}
-                {{ 'dashboard.ez_version.non_stable_packages'|trans({'%stability%': ez.stability})|desc("Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.") }}
+                {{ 'dashboard.ez_version.non_stable_packages'|trans({'%stability%': ez.stability})|desc("Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.") }}
             {% endif %}
             {% if ez.isEnterpise %}
                 {{ 'dashboard.ez_version.non_stable_ee'|trans({'%support_url%': urls['support']})|desc("If you need assistance, don't hesitate to <a target=\"_blank\" href=\"%support_url%\">get in touch with eZ support</a>.")|raw }}

--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -23,7 +23,7 @@
         {% set badge = 'Development' %}
         <div class="alert alert-warning mb-0 mt-3" role="alert">
             {% if ez.composerInfo.minimumStability != 'stable' %}
-                {{ 'dashboard.ez_version.unstable_minimum_stability'|trans({'%minimum_stability%': ez.composerInfo.minimumStability})|desc("Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.") }}
+                {{ 'dashboard.ez_version.unstable_minimum_stability'|trans({'%minimum_stability%': ez.composerInfo.minimumStability})|desc("Your setup is running with '%minimum_stability%' as composer.json minimum-stability. This is not recommended except when testing updates or during development.") }}
             {% else  %}
                 {{ 'dashboard.ez_version.non_stable_packages'|trans({'%stability%': ez.stability})|desc("Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.") }}
             {% endif %}

--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -23,7 +23,7 @@
         {% set badge = 'Development' %}
         <div class="alert alert-warning mb-0 mt-3" role="alert">
             {% if ez.composerInfo.minimumStability != 'stable' %}
-                {{ 'dashboard.ez_version.unstable_minimum_stability'|trans({'%minimum_stability%': ez.composerInfo.minimumStability})|desc("Your setup is running with '%minimum_stability%' as composer.json minimumStability, this is not recommended besides when testing updates or during development.") }}
+                {{ 'dashboard.ez_version.unstable_minimum_stability'|trans({'%minimum_stability%': ez.composerInfo.minimumStability})|desc("Your setup is running with '%minimum_stability%' as composer.json minimum-stability, this is not recommended besides when testing updates or during development.") }}
             {% else  %}
                 {{ 'dashboard.ez_version.non_stable_packages'|trans({'%stability%': ez.stability})|desc("Your setup is running with @%stability% composer packages, this is not recommended besides when testing updates or during development.") }}
             {% endif %}

--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -135,7 +135,7 @@ class EzSystemInfoCollector implements SystemInfoCollector
      */
     public function collect()
     {
-        $ez = new EzSystemInfo(['debug' => $this->debug]);
+        $ez = new EzSystemInfo(['debug' => $this->debug, 'composerInfo' => $this->composerInfo]);
         if ($this->composerInfo === null) {
             return $ez;
         }

--- a/SystemInfo/Value/EzSystemInfo.php
+++ b/SystemInfo/Value/EzSystemInfo.php
@@ -61,4 +61,9 @@ class EzSystemInfo extends ValueObject implements SystemInfo
      * @var bool
      */
     public $debug;
+
+    /**
+     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo|null
+     */
+    public $composerInfo;
 }


### PR DESCRIPTION
Does:
- Always show dev message if in dev, even if in debug mode, so Engineering Sprint demos won't show `Trial` badge
- Change the message to be more concrete to make it hopefully more clear what user needs to do to fix it

<img width="957" alt="Screenshot 2019-08-30 at 10 06 55 " src="https://user-images.githubusercontent.com/289757/64004121-f5c73f80-cb0d-11e9-9b92-be3bbb6a0924.png">
