### PR TITLE
EZP-31007: Changed eZ Platform version detection

### DIFF
--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
 
+use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\EzSystemInfo;
 use DateTime;
@@ -138,11 +139,7 @@ class EzSystemInfoCollector implements SystemInfoCollector
             return $ez;
         }
 
-        // The most reliable way to get version is from kernel
-        // future updates should make sure to detect when kernel version selector is wrong compare to other packages
-        if (isset($this->composerInfo->packages['ezsystems/ezpublish-kernel'])) {
-            $ez->release = (string)(((float)$this->composerInfo->packages['ezsystems/ezpublish-kernel']->version) - 5);
-        }
+        $ez->release = EzPlatformCoreBundle::VERSION;
 
         // In case someone switches from TTL to BUL, make sure we only identify install as Trial if this is present,
         // as well as TTL packages

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": "^7.3",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
+        "ezsystems/ezplatform-core": "^2.0@dev",
         "ocramius/proxy-manager": "^2.2",
         "symfony/proxy-manager-bridge": "^5.0",
         "zetacomponents/system-information": "^1.1.1",
@@ -20,6 +21,7 @@
     "require-dev": {
         "ezsystems/ezplatform-code-style": "^0.1",
         "friendsofphp/php-cs-fixer": "^2.16",
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "phpunit/phpunit": "^8.2"
     },
     "autoload": {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Requires** | ezsystems/ezplatform-core#16
| **Target version** | `2.0` for eZ Platform `v3.0`
| **BC breaks**      | no

Due to ezsystems/ezplatform#510, explained in ezsystems/ezplatform-core#16.