### PR TITLE
Fixed eZ Platform EOM/EOL detection

### DIFF
--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -129,6 +129,9 @@ class EzSystemInfoCollector implements SystemInfoCollector
         }
 
         $ez->release = EzPlatformCoreBundle::VERSION;
+        // try to extract version number, but prepare for unexpected string
+        [$majorVersion, $minorVersion] = array_pad(explode('.', $ez->release), 2, '');
+        $eZRelease = "{$majorVersion}.{$minorVersion}";
 
         // In case someone switches from TTL to BUL, make sure we only identify install as Trial if this is present,
         // as well as TTL packages
@@ -146,21 +149,21 @@ class EzSystemInfoCollector implements SystemInfoCollector
             $ez->name = 'eZ Commerce';
         }
 
-        if ($ez->isTrial && isset(self::RELEASES[$ez->release])) {
-            $months = (new DateTime(self::RELEASES[$ez->release]))->diff(new DateTime())->m;
+        if ($ez->isTrial && isset(self::RELEASES[$eZRelease])) {
+            $months = (new DateTime(self::RELEASES[$eZRelease]))->diff(new DateTime())->m;
             $ez->isEndOfMaintenance = $months > 3;
             // @todo We need to detect this in a better way, this is temporary until some of the work described in class doc is done.
             $ez->isEndOfLife = $months > 6;
         } else {
-            if (isset(self::EOM[$ez->release])) {
-                $ez->isEndOfMaintenance = strtotime(self::EOM[$ez->release]) < time();
+            if (isset(self::EOM[$eZRelease])) {
+                $ez->isEndOfMaintenance = strtotime(self::EOM[$eZRelease]) < time();
             }
 
-            if (isset(self::EOL[$ez->release])) {
+            if (isset(self::EOL[$eZRelease])) {
                 if (!$ez->isEnterpise) {
                     $ez->isEndOfLife = $ez->isEndOfMaintenance;
                 } else {
-                    $ez->isEndOfLife = strtotime(self::EOL[$ez->release]) < time();
+                    $ez->isEndOfLife = strtotime(self::EOL[$eZRelease]) < time();
                 }
             }
         }

--- a/Tests/SystemInfo/Collector/EzSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/EzSystemInfoCollectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace SystemInfo\Collector;
+
+use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzSystemInfoCollector;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector;
+use PHPUnit\Framework\TestCase;
+
+class EzSystemInfoCollectorTest extends TestCase
+{
+    public function testCollect(): void
+    {
+        $composerCollector = new JsonComposerLockSystemInfoCollector(
+            __DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/composer.json'
+        );
+
+        $systemInfoCollector = new EzSystemInfoCollector($composerCollector);
+        $systemInfo = $systemInfoCollector->collect();
+        self::assertSame('eZ Platform', $systemInfo->name);
+        self::assertSame(EzPlatformCoreBundle::VERSION, $systemInfo->release);
+    }
+}


### PR DESCRIPTION
This is a follow up to [EZP-31007](https://jira.ez.no/browse/EZP-31007) via #47 

When working on #47, in reference to `ezplatform-kernel` package being gone, I've missed the fact that `$ez->release` is needed in the `X.Y` format to detect EOM & EOL state.

It results in a following incorrect message on the AdminUI Dasboard:

![image](https://user-images.githubusercontent.com/7099219/78283362-f6014080-751d-11ea-9fda-2b89662d9a13.png)

_This requires more work to be future-proof. The PR provides minimum reasonable fix along with missing test coverage. The point of test coverage, while not testing directly processing of version number, was to detect any parsing errors in the future. Right now there's no point testing EOM/EOL detection as this will definitely fail in the future because the dates are hardcoded._
