### PR TITLE
Exclude patch for release

### DIFF
--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -128,7 +128,8 @@ class EzSystemInfoCollector implements SystemInfoCollector
             return $ez;
         }
 
-        $ez->release = EzPlatformCoreBundle::VERSION;
+        $versionParts = explode('.', EzPlatformCoreBundle::VERSION);
+        $ez->release = $versionParts[0] . '.' . $versionParts[1];
 
         // In case someone switches from TTL to BUL, make sure we only identify install as Trial if this is present,
         // as well as TTL packages


### PR DESCRIPTION
After upgrading one of our projects to https://github.com/ezsystems/ezplatform/releases/tag/v3.0.0 following warning is show:
![Screen Shot 2020-04-02 at 2 18 21 PM](https://user-images.githubusercontent.com/166894/78289363-10242a00-74f0-11ea-885f-24afbd149a81.png)
