### PR TITLE
Update v3.1 release/lifetime dates

### DIFF
--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -38,7 +38,7 @@ class EzSystemInfoCollector implements SystemInfoCollector
         '2.4' => '2018-12-20T23:59:59+00:00',
         '2.5' => '2019-03-29T16:59:59+00:00',
         '3.0' => '2020-04-02T23:59:59+00:00',
-        '3.1' => '2020-07-06T23:59:59+00:00', // Estimate at time of writing
+        '3.1' => '2020-07-15T23:59:59+00:00',
     ];
 
     /**
@@ -62,7 +62,7 @@ class EzSystemInfoCollector implements SystemInfoCollector
         '2.4' => '2019-03-20T23:59:59+00:00',
         '2.5' => '2022-03-29T23:59:59+00:00',
         '3.0' => '2020-07-10T23:59:59+00:00',
-        '3.1' => '2020-09-30T23:59:59+00:00', // Estimate at time of writing
+        '3.1' => '2020-09-30T23:59:59+00:00',
     ];
 
     /**
@@ -80,7 +80,7 @@ class EzSystemInfoCollector implements SystemInfoCollector
         '2.4' => '2019-06-20T23:59:59+00:00',
         '2.5' => '2024-03-29T23:59:59+00:00',
         '3.0' => '2020-08-31T23:59:59+00:00',
-        '3.1' => '2020-11-30T23:59:59+00:00', // Estimate at time of writing
+        '3.1' => '2020-11-30T23:59:59+00:00',
     ];
 
     /**


### PR DESCRIPTION
v3.1 dates can be nailed now.

v3.2 release is expected at September 28th, but EOM/EOL dates are not known. Afaik it's not clear if 3.2 will be FT or LTS, so for now I haven't set these. Let me know if you have more info.