### PR TITLE
Missing success code for the SystemInfoDumpCommand

### DIFF
--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -107,7 +107,9 @@ EOD
         }
 
         $output->writeln(
-             $outputFormatter->format($collectedInfoArray)
-         );
+            $outputFormatter->format($collectedInfoArray)
+        );
+
+        return Command::SUCCESS;
     }
 }

--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -87,7 +87,7 @@ EOD
                 $output->writeln("  $identifier", true);
             }
 
-            return;
+            return Command::SUCCESS;
         }
 
         $outputFormatter = $this->outputFormatRegistry->getItem(


### PR DESCRIPTION
Symfony 5 commands need to return an exit code that is currently missing. Due to that, the command results in error in eZ Platform 3.1:
```Return value of "EzSystems\EzSupportToolsBundle\Command\SystemInfoDumpCommand::execute()" must be of the type int, "null" returned.```