### PR TITLE
[DX] Setup short forward compatible 'ibexa:info' aliases for system info dump command

### DIFF
--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -48,7 +48,6 @@ class SystemInfoDumpCommand extends ContainerAwareCommand
         $this
             ->setName('ez-support-tools:dump-info')
             ->setAliases([
-                'ez:info',
                 'ibexa:info',
             ])
             ->setDescription('Collects system information and dumps it.')

--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -47,6 +47,10 @@ class SystemInfoDumpCommand extends ContainerAwareCommand
     {
         $this
             ->setName('ez-support-tools:dump-info')
+            ->setAliases([
+                'ez:info',
+                'ibexa:info',
+            ])
             ->setDescription('Collects system information and dumps it.')
             ->setHelp(<<<'EOD'
 By default it dumps information from all available information collectors.

--- a/Command/SystemInfoDumpCommand.php
+++ b/Command/SystemInfoDumpCommand.php
@@ -48,6 +48,7 @@ class SystemInfoDumpCommand extends ContainerAwareCommand
         $this
             ->setName('ez-support-tools:dump-info')
             ->setAliases([
+                'ibexa:dump-info',
                 'ibexa:info',
             ])
             ->setDescription('Collects system information and dumps it.')


### PR DESCRIPTION
Forward compatibility, as we often instructs customer to run this, and don't always know which version they are on (upgrades and so on.)

This also simplify instructions for how to dump info about the system.