### PR TITLE
[3.3] Add Composer subscription plugin to sync subscription info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3",
-        "composer-plugin-api": "^2.0",
+        "composer-plugin-api": "^1.1 || ^2.0",
         "ezsystems/ezplatform-kernel": "^1.3@dev",
         "ezsystems/ezplatform-core": "^2.1@dev",
         "ezsystems/ezplatform-admin-ui": "^2.2@dev",
@@ -20,7 +20,6 @@
         "zetacomponents/system-information": "^1.1.1"
     },
     "require-dev": {
-        "composer/composer": "^2.0",
         "ezsystems/ezplatform-code-style": "^0.1",
         "friendsofphp/php-cs-fixer": "^2.16",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.3",
+        "ext-json": "*",
         "composer-plugin-api": "^1.1 || ^2.0",
         "ezsystems/ezplatform-kernel": "^1.3@dev",
         "ezsystems/ezplatform-core": "^2.1@dev",
@@ -20,6 +21,7 @@
         "zetacomponents/system-information": "^1.1.1"
     },
     "require-dev": {
+        "composer/composer": "^2.0",
         "ezsystems/ezplatform-code-style": "^0.1",
         "friendsofphp/php-cs-fixer": "^2.16",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ezsystems/ez-support-tools",
     "description": "Providing information about the system eZ Platform/Enterprise/Commerce is running on, and eZ install itself",
     "license": "GPL-2.0",
-    "type": "ezplatform-bundle",
+    "type": "composer-plugin",
     "authors": [
         {
             "name": "eZ Systems",
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.3",
+        "composer-plugin-api": "^2.0",
         "ezsystems/ezplatform-kernel": "^1.3@dev",
         "ezsystems/ezplatform-core": "^2.1@dev",
         "ezsystems/ezplatform-admin-ui": "^2.2@dev",
@@ -19,6 +20,7 @@
         "zetacomponents/system-information": "^1.1.1"
     },
     "require-dev": {
+        "composer/composer": "^2.0",
         "ezsystems/ezplatform-code-style": "^0.1",
         "friendsofphp/php-cs-fixer": "^2.16",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
@@ -33,6 +35,7 @@
     },
     "extra": {
         "_ezplatform_branch_for_behat_tests": "master",
+        "class": "EzSystems\\EzSupportTools\\Composer\\SubscriptionPlugin",
         "branch-alias": {
             "dev-master": "2.3.x-dev",
             "dev-tmp_ci_branch": "2.3.x-dev"

--- a/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -61,9 +61,9 @@ class EzSystemsEzSupportToolsExtension extends Extension
 
         // Autodetect product name
         $name = self::getNameBySubscriptionInfo($vendor . 'ibexa/subscription.json');
-        if (!$name) {
+        if (empty($name)) {
             // Fallback to detect name by packages
-            $name = self::getNameByPackages();
+            $name = self::getNameByPackages($vendor);
         }
 
         if ($release === 'major') {
@@ -100,14 +100,18 @@ class EzSystemsEzSupportToolsExtension extends Extension
         return $name;
     }
 
-    private static function getNameByPackages(): string
+    private static function getNameByPackages(string $vendor): string
     {
         if (is_dir($vendor . IbexaSystemInfoCollector::COMMERCE_PACKAGES[0])) {
             $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['commerce'];
         } elseif (is_dir($vendor . IbexaSystemInfoCollector::ENTERPRISE_PACKAGES[0])) {
             $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['experience'];
+        } elseif (is_dir($vendor . IbexaSystemInfoCollector::CONTENT_PACKAGES[0])) {
+            $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['content'];
         } else {
             $name = IbexaSystemInfo::PRODUCT_NAME_OSS;
         }
+
+        return $name;
     }
 }

--- a/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -104,7 +104,7 @@ class EzSystemsEzSupportToolsExtension extends Extension
     {
         if (is_dir($vendor . IbexaSystemInfoCollector::COMMERCE_PACKAGES[0])) {
             $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['commerce'];
-        } elseif (is_dir($vendor . IbexaSystemInfoCollector::ENTERPRISE_PACKAGES[0])) {
+        } elseif (is_dir($vendor . IbexaSystemInfoCollector::EXPERIENCE_PACKAGES[0])) {
             $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['experience'];
         } elseif (is_dir($vendor . IbexaSystemInfoCollector::CONTENT_PACKAGES[0])) {
             $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['content'];

--- a/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -100,7 +100,7 @@ class EzSystemsEzSupportToolsExtension extends Extension
         return $name;
     }
 
-    private static function getNameByPackages(string $vendor): string
+    public static function getNameByPackages(string $vendor): string
     {
         if (is_dir($vendor . IbexaSystemInfoCollector::COMMERCE_PACKAGES[0])) {
             $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['commerce'];

--- a/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsEzSupportToolsExtension.php
@@ -79,7 +79,7 @@ class EzSystemsEzSupportToolsExtension extends Extension
     private static function getNameBySubscriptionInfo(string $file): ?string
     {
         if (!file_exists($file)) {
-            return;
+            return null;
         }
 
         $subscriptionData = json_decode(file_get_contents($file), true);
@@ -100,7 +100,7 @@ class EzSystemsEzSupportToolsExtension extends Extension
         return $name;
     }
 
-    private static function getNameByPackages(): ?string
+    private static function getNameByPackages(): string
     {
         if (is_dir($vendor . IbexaSystemInfoCollector::COMMERCE_PACKAGES[0])) {
             $name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS['commerce'];

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -18,19 +18,19 @@ parameters:
     support_tools.system_info.output_format.json.class: EzSystems\EzSupportToolsBundle\SystemInfo\OutputFormat\JsonOutputFormat
     ezplatform_support_tools.system_info.powered_by.name: ''
     support_tools.ez_url_list:
-        contact: "https://ez.no/About-eZ/Contact-Us"
-        license: "https://ez.no/About-our-Software/Licenses-and-agreements"
-        ttl: "https://ez.no/About-our-Software/Licenses-and-agreements/eZ-Trial-and-Test-License-Agreement-eZ-TTL-v2.1"
-        service_life: "https://support.ez.no/Public/Service-Life"
-        support_service: "https://ez.no/Services/Support-Maintenance"
-        training_service: "https://ez.no/Services/Training"
-        consulting_service: "https://ez.no/Services/Consulting"
-        ee_product: "https://ez.no/Products/eZ-Platform-Enterprise-Edition"
-        install_ee: "https://doc.ezplatform.com/en/{ez.release}/getting_started/install_ez_enterprise/"
-        doc: "https://doc.ezplatform.com"
-        update: "https://doc.ezplatform.com/en/latest/releases/updating_ez_platform/"
+        contact: "https://www.ibexa.co/about-ibexa/contact-us"
+        license: "https://www.ibexa.co/software-information/licenses-and-agreements"
+        ttl: "https://www.ibexa.co/software-information/licenses-and-agreements/ez-trial-and-test-license-agreement-ez-ttl-v2.1"
+        service_life: "https://support.ibexa.co/Public/Service-Life"
+        support_service: "https://www.ibexa.co/services/support-maintenance"
+        training_service: "https://www.ibexa.co/services/training"
+        consulting_service: "https://www.ibexa.co/services/consulting-services"
+        ee_product: "https://www.ibexa.co/products"
+        install_ee: "https://doc.ibexa.co/en/{ez.release}/getting_started/install_ez_platform/"
+        doc: "https://doc.ibexa.co"
+        update: "https://doc.ibexa.co/en/latest/updating/updating_ez_platform"
         gpl_faq: "https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.en.html#GPLModuleLicense"
-        support: "https://support.ez.no"
+        support: "https://support.ibexa.co"
 
 services:
     # EventSubscriber

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -67,6 +67,7 @@ services:
         arguments:
             - "@support_tools.system_info.collector.composer.lock_file"
             - "%kernel.debug%"
+            - "%kernel.project_dir%/vendor/ibexa/subscription.json"
         tags:
             - { name: "support_tools.system_info.collector", identifier: "ibexa" }
 

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -63,11 +63,12 @@ services:
     # SystemInfoCollectors
 
     support_tools.system_info.collector.system.ibexa:
-        class: "%support_tools.system_info.collector.system.ibexa.class%"
+        class: '%support_tools.system_info.collector.system.ibexa.class%'
         arguments:
-            - "@support_tools.system_info.collector.composer.lock_file"
-            - "%kernel.debug%"
-            - "%kernel.project_dir%/vendor/ibexa/subscription.json"
+            $composerCollector: "@support_tools.system_info.collector.composer.lock_file"
+            $kernelProjectDir: '%kernel.project_dir%'
+            $debug: '%kernel.debug%'
+            $subscriptionFile: '%kernel.project_dir%/vendor/ibexa/subscription.json'
         tags:
             - { name: "support_tools.system_info.collector", identifier: "ibexa" }
 

--- a/src/bundle/Resources/translations/dashboard.en.xliff
+++ b/src/bundle/Resources/translations/dashboard.en.xliff
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="1710718593a511e351e6da36e3bb280e532bb768" resname="dashboard.ez_version.community_end_of_maintenance">
+        <source><![CDATA[Unfortunately %release% open source version has reached end of life,
+                        <a target="_blank" href="%update_url%">please upgrade</a>.]]></source>
+        <target state="new"><![CDATA[Unfortunately %release% open source version has reached end of life,
+                        <a target="_blank" href="%update_url%">please upgrade</a>.]]></target>
+        <note>key: dashboard.ez_version.community_end_of_maintenance</note>
+      </trans-unit>
+      <trans-unit id="c0d043ecd29c0bdfa32e8bb7faee57111d5ddaf7" resname="dashboard.ez_version.community_end_of_maintenance_upgrade">
+        <source><![CDATA[Tip: If you upgrade to Ibexa DXP you'll get access to:
+                            <a target="_blank" href="%license_url%">A business friendly license</a>,
+                            <a target="_blank" href="%ee_product_url%">several productivity features</a>,
+                            <a target="_blank" href="%support_service_url%">professional support</a> and a
+                            <a target="_blank" href="%service_life_url%">longer maintenance period of your release</a>.]]></source>
+        <target state="new"><![CDATA[Tip: If you upgrade to Ibexa DXP you'll get access to:
+                            <a target="_blank" href="%license_url%">A business friendly license</a>,
+                            <a target="_blank" href="%ee_product_url%">several productivity features</a>,
+                            <a target="_blank" href="%support_service_url%">professional support</a> and a
+                            <a target="_blank" href="%service_life_url%">longer maintenance period of your release</a>.]]></target>
+        <note>key: dashboard.ez_version.community_end_of_maintenance_upgrade</note>
+      </trans-unit>
+      <trans-unit id="7eb6ab2973439efa8ff820310952e02bc81209cb" resname="dashboard.ez_version.community_severity_non">
+        <source><![CDATA[Welcome to the open source %release% release. Using the community friendly <a target="_blank" href="%license_url%">GPL license</a>,
+                        <a target="_blank" href="%gpl_faq_url%">sharing your code</a> is what it's all about.]]></source>
+        <target state="new"><![CDATA[Welcome to the open source %release% release. Using the community friendly <a target="_blank" href="%license_url%">GPL license</a>,
+                        <a target="_blank" href="%gpl_faq_url%">sharing your code</a> is what it's all about.]]></target>
+        <note>key: dashboard.ez_version.community_severity_non</note>
+      </trans-unit>
+      <trans-unit id="9bad0b8d1efd71dca8071e736f332b3b4218d557" resname="dashboard.ez_version.end_of_life_upgrade">
+        <source><![CDATA[Unfortunately %release% has reached <a target="_blank" href="%service_life_url%">end of life</a>,
+                    please plan to upgrade. If you need assistance, don't hesitate to <a target="_blank" href="%contact_url%">contact eZ</a>.]]></source>
+        <target state="new"><![CDATA[Unfortunately %release% has reached <a target="_blank" href="%service_life_url%">end of life</a>,
+                    please plan to upgrade. If you need assistance, don't hesitate to <a target="_blank" href="%contact_url%">contact eZ</a>.]]></target>
+        <note>key: dashboard.ez_version.end_of_life_upgrade</note>
+      </trans-unit>
+      <trans-unit id="59967d79ef1f521fd483dbb057f15bc756b80423" resname="dashboard.ez_version.non_stable_ee">
+        <source><![CDATA[If you need assistance, don't hesitate to <a target="_blank" href="%support_url%">get in touch with Ibexa support</a>.]]></source>
+        <target state="new"><![CDATA[If you need assistance, don't hesitate to <a target="_blank" href="%support_url%">get in touch with Ibexa support</a>.]]></target>
+        <note>key: dashboard.ez_version.non_stable_ee</note>
+      </trans-unit>
+      <trans-unit id="b6fb485c551af76b514c1ed339cc2607146b7ebe" resname="dashboard.ez_version.non_stable_packages">
+        <source>Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.</source>
+        <target state="new">Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.</target>
+        <note>key: dashboard.ez_version.non_stable_packages</note>
+      </trans-unit>
+      <trans-unit id="c1fb5ba9fd547e30a49a4e1895822e69cd4a9dbc" resname="dashboard.ez_version.release_not_determined">
+        <source><![CDATA[The system could not find your <code>composer.lock</code> file. It's needed to determine information about
+                    your Ibexa installation. It is recommended to keep it during project development to make sure the same package versions are
+                    used across all environments.]]></source>
+        <target state="new"><![CDATA[The system could not find your <code>composer.lock</code> file. It's needed to determine information about
+                    your Ibexa installation. It is recommended to keep it during project development to make sure the same package versions are
+                    used across all environments.]]></target>
+        <note>key: dashboard.ez_version.release_not_determined</note>
+      </trans-unit>
+      <trans-unit id="4660c21d37256c5a34b768ca45c7d90890bc164a" resname="dashboard.ez_version.subscription_missing">
+        <source><![CDATA[The system could not find your <code>%file%</code> file.
+                For Ibexa DXP installations this is needed to determine access to features and give you feedback if something is not working correctly.
+                Please run <code>%command%</code> to synchronize this info from our updates.ibexa.co servers.]]></source>
+        <target state="new"><![CDATA[The system could not find your <code>%file%</code> file.
+                For Ibexa DXP installations this is needed to determine access to features and give you feedback if something is not working correctly.
+                Please run <code>%command%</code> to synchronize this info from our updates.ibexa.co servers.]]></target>
+        <note>key: dashboard.ez_version.subscription_missing</note>
+      </trans-unit>
+      <trans-unit id="d2da7429d16bd8443b6f2368319e64d6e537dfd6" resname="dashboard.ez_version.trial_contact">
+        <source><![CDATA[<a target="_blank" href="%contact_url%">Contact Ibexa or its partner(s)</a> to purchase a subscription
+                        and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure composer.json 'repositories' url for 'bul' instead of 'ttl'.]]></source>
+        <target state="new"><![CDATA[<a target="_blank" href="%contact_url%">Contact Ibexa or its partner(s)</a> to purchase a subscription
+                        and follow the <a target="_blank" href="%install_ee%">online documentation</a> to configure composer.json 'repositories' url for 'bul' instead of 'ttl'.]]></target>
+        <note>key: dashboard.ez_version.trial_contact</note>
+      </trans-unit>
+      <trans-unit id="e0a1a502c52dddb0acc187d429d7e7e4b754e169" resname="dashboard.ez_version.trial_end_of_maintenance">
+        <source>Your trial period is coming to an end.</source>
+        <target state="new">Your trial period is coming to an end.</target>
+        <note>key: dashboard.ez_version.trial_end_of_maintenance</note>
+      </trans-unit>
+      <trans-unit id="10afa9a6e250d82f948ea1e6cbcdf7aac8bd7a4b" resname="dashboard.ez_version.trial_expired">
+        <source><![CDATA[Unfortunately your trial period has expired and your <a target="_blank" href="%ttl_url%">TTL license</a> is no longer valid.]]></source>
+        <target state="new"><![CDATA[Unfortunately your trial period has expired and your <a target="_blank" href="%ttl_url%">TTL license</a> is no longer valid.]]></target>
+        <note>key: dashboard.ez_version.trial_expired</note>
+      </trans-unit>
+      <trans-unit id="d8aa12a1ad613c385056cbd9b7cf5bffd0ad2ce9" resname="dashboard.ez_version.trial_notice">
+        <source><![CDATA[Welcome to %name%, check our <a target="_blank" href="%doc_url%">online documentation</a>, <a target="_blank" href="%consulting_url%">consulting</a>
+                        or <a target="_blank" href="%training_url%">training</a> services in order to get the most out of your trial.]]></source>
+        <target state="new"><![CDATA[Welcome to %name%, check our <a target="_blank" href="%doc_url%">online documentation</a>, <a target="_blank" href="%consulting_url%">consulting</a>
+                        or <a target="_blank" href="%training_url%">training</a> services in order to get the most out of your trial.]]></target>
+        <note>key: dashboard.ez_version.trial_notice</note>
+      </trans-unit>
+      <trans-unit id="b45117cfedb50a78f75f7bb6592107507d9348e1" resname="dashboard.ez_version.unstable_minimum_stability">
+        <source>Your setup is running with '%minimum_stability%' as composer.json minimum-stability. This is not recommended except when testing updates or during development.</source>
+        <target state="new">Your setup is running with '%minimum_stability%' as composer.json minimum-stability. This is not recommended except when testing updates or during development.</target>
+        <note>key: dashboard.ez_version.unstable_minimum_stability</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/translations/menu.en.xliff
+++ b/src/bundle/Resources/translations/menu.en.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="2cc622305036d330c00683520df433ef82f60c9a" resname="main__admin__systeminfo">
+        <source>System Information</source>
+        <target state="new">System Information</target>
+        <note>key: main__admin__systeminfo</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="d21d07085caa55b0fee2fc054a6878bbdb24ae78" resname="breadcrumb.admin">
+        <source>Admin</source>
+        <target state="new">Admin</target>
+        <note>key: breadcrumb.admin</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/translations/systeminfo.en.xliff
+++ b/src/bundle/Resources/translations/systeminfo.en.xliff
@@ -56,50 +56,70 @@
         <target state="new">Disabled</target>
         <note>key: disabled</note>
       </trans-unit>
-      <trans-unit id="d87becd0d1497fe04536d2e9291290a8b07e9dfb" resname="ibexa.product">
-        <source>Product</source>
-        <target state="new">Product</target>
-        <note>key: ibexa.product</note>
-      </trans-unit>
-      <trans-unit id="b7ffaa791bbf39db2ea700efec5362a0bc4e2021" resname="ibexa.name">
-        <source>Name</source>
-        <target state="new">Name</target>
-        <note>key: ibexa.name</note>
-      </trans-unit>
-      <trans-unit id="d6025d67b03f12dac6c912f6224bb309347f6465" resname="ibexa.version">
-        <source>Version</source>
-        <target state="new">Version</target>
-        <note>key: ibexa.version</note>
-      </trans-unit>
-      <trans-unit id="4a9e6f9b28c3203784cb5f01ebe73e67661cc823" resname="ibexa.eom">
-        <source>End of Maintenance</source>
-        <target state="new">End of Maintenance</target>
-        <note>key: ibexa.eom</note>
+      <trans-unit id="608cb271bb7fb52c99a1a8e003e0f80f57fb41e1" resname="hardware">
+        <source>Hardware</source>
+        <target state="new">Hardware</target>
+        <note>key: hardware</note>
       </trans-unit>
       <trans-unit id="ed1f723e05fbc74c1c90cfc6f64c2bcda6f4bb9d" resname="ibexa.eol">
         <source>End of Life</source>
         <target state="new">End of Life</target>
         <note>key: ibexa.eol</note>
       </trans-unit>
+      <trans-unit id="4a9e6f9b28c3203784cb5f01ebe73e67661cc823" resname="ibexa.eom">
+        <source>End of Maintenance</source>
+        <target state="new">End of Maintenance</target>
+        <note>key: ibexa.eom</note>
+      </trans-unit>
       <trans-unit id="804e14084add4426182add3b4a0a710506ef742b" resname="ibexa.is_trial">
         <source>Is Trial</source>
         <target state="new">Is Trial</target>
         <note>key: ibexa.is_trial</note>
       </trans-unit>
-      <trans-unit id="341340ab8c700ad6fe83322ec29cb3977262f5df" resname="ibexa.stability">
-        <source>Stability</source>
-        <target state="new">Stability</target>
-        <note>key: ibexa.stability</note>
+      <trans-unit id="b7ffaa791bbf39db2ea700efec5362a0bc4e2021" resname="ibexa.name">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note>key: ibexa.name</note>
+      </trans-unit>
+      <trans-unit id="4c4cc8e04ed19250e8ea5416568695f9cbaa4216" resname="ibexa.no_subscription">
+        <source>This installation is currently running the Open Source version, which does not come with any subscription</source>
+        <target state="new">This installation is currently running the Open Source version, which does not come with any subscription</target>
+        <note>key: ibexa.no_subscription</note>
+      </trans-unit>
+      <trans-unit id="d87becd0d1497fe04536d2e9291290a8b07e9dfb" resname="ibexa.product">
+        <source>Product</source>
+        <target state="new">Product</target>
+        <note>key: ibexa.product</note>
       </trans-unit>
       <trans-unit id="972bcf808b8ce2b0a08a21db7f0f15f520f4b87b" resname="ibexa.read_more">
         <source>You can read more about Service Life for Ibexa DXP with a business license at</source>
         <target state="new">You can read more about Service Life for Ibexa DXP with a business license at</target>
         <note>key: ibexa.read_more</note>
       </trans-unit>
-      <trans-unit id="608cb271bb7fb52c99a1a8e003e0f80f57fb41e1" resname="hardware">
-        <source>Hardware</source>
-        <target state="new">Hardware</target>
-        <note>key: hardware</note>
+      <trans-unit id="341340ab8c700ad6fe83322ec29cb3977262f5df" resname="ibexa.stability">
+        <source>Stability</source>
+        <target state="new">Stability</target>
+        <note>key: ibexa.stability</note>
+      </trans-unit>
+      <trans-unit id="17ce2d213058425213ad646e084dd153538b5a15" resname="ibexa.subscription">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note>key: ibexa.subscription</note>
+      </trans-unit>
+      <trans-unit id="528a90191f57d1f451ad7a6b3b7a39ef5710c56a" resname="ibexa.subscription_expiry">
+        <source>Subscription renewal date</source>
+        <target state="new">Subscription renewal date</target>
+        <note>key: ibexa.subscription_expiry</note>
+      </trans-unit>
+      <trans-unit id="0bc50eddbd4fbd2847591449f1f8e267a8d2d0ec" resname="ibexa.subscription_info_missing">
+        <source>Subscription info was missing on installation, run the following command to synchronize it</source>
+        <target state="new">Subscription info was missing on installation, run the following command to synchronize it</target>
+        <note>key: ibexa.subscription_info_missing</note>
+      </trans-unit>
+      <trans-unit id="d6025d67b03f12dac6c912f6224bb309347f6465" resname="ibexa.version">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note>key: ibexa.version</note>
       </trans-unit>
       <trans-unit id="81c5d49be9505089d8d248ea96f6d077fd0ab9bd" resname="memory">
         <source>Memory</source>
@@ -216,11 +236,6 @@
         <target state="new">System Information</target>
         <note>key: systeminfo</note>
       </trans-unit>
-      <trans-unit id="7dd1b2ca71037e00112dfe0297383f47c6904c77" resname="tab.name.ibexa">
-        <source>My Ibexa</source>
-        <target state="new">My Ibexa</target>
-        <note>key: tab.name.ibexa</note>
-      </trans-unit>
       <trans-unit id="a2a92e9d0e41ea4a14c99ab0f702d5df3ea017c3" resname="tab.name.composer">
         <source>Composer</source>
         <target state="new">Composer</target>
@@ -235,6 +250,11 @@
         <source>Hardware</source>
         <target state="new">Hardware</target>
         <note>key: tab.name.hardware</note>
+      </trans-unit>
+      <trans-unit id="7dd1b2ca71037e00112dfe0297383f47c6904c77" resname="tab.name.ibexa">
+        <source>My Ibexa</source>
+        <target state="new">My Ibexa</target>
+        <note>key: tab.name.ibexa</note>
       </trans-unit>
       <trans-unit id="b71f0d567a424182b8c83a6b90a262b29819241b" resname="tab.name.php">
         <source>PHP</source>

--- a/src/bundle/Resources/views/themes/admin/system_info/my_ibexa.html.twig
+++ b/src/bundle/Resources/views/themes/admin/system_info/my_ibexa.html.twig
@@ -67,23 +67,17 @@
                         {{ info.subscriptionExpiryDate|date('F Y') }}
                     </td>
                 </tr>
-                <tr class="ez-table__row">
-                    <td colspan="2">
-                        <hr/>
-                        * {{ 'ibexa.subscription_read_more'|trans|desc('Subscription renewal date does not reflect auto renawal, and typically does not represent when the subscription ends') }}
-                    </td>
-                </tr>
             {% elseif info.shouldHaveSubscription %}
                 <tr class="ez-table__row">
                     <td class="ez-table__cell ez-alert__content">
-                        {{ 'ibexa.subscription_info_missing'|trans|desc('Subscription info was missing on installation, run the following command to syncronize it') }}
+                        {{ 'ibexa.subscription_info_missing'|trans|desc('Subscription info was missing on installation, run the following command to synchronize it') }}
                         <code>composer run ibexa:sync-subscription</code>
                     </td>
                 </tr>
             {% else %}
                 <tr class="ez-table__row">
                     <td class="ez-table__cell">
-                        {{ 'ibexa.no_subscription'|trans|desc('This install is currently running on Open Source version, which does not come with any subscription') }}
+                        {{ 'ibexa.no_subscription'|trans|desc('This installation is currently running the Open Source version, which does not come with any subscription') }}
                     </td>
                 </tr>
             {% endif %}

--- a/src/bundle/Resources/views/themes/admin/system_info/my_ibexa.html.twig
+++ b/src/bundle/Resources/views/themes/admin/system_info/my_ibexa.html.twig
@@ -16,14 +16,6 @@
                     <td class="ez-table__cell">{{ info.release }}</td>
                 </tr>
                 <tr class="ez-table__row">
-                    <td class="ez-table__cell">{{ 'ibexa.is_trial'|trans|desc('Is Trial') }}</td>
-                    <td class="ez-table__cell">
-                        <svg class="ez-icon ez-icon--small">
-                            <use xlink:href="{{ ez_icon_path(info.isTrial ? 'checkmark' : 'discard') }}"></use>
-                        </svg>
-                    </td>
-                </tr>
-                <tr class="ez-table__row">
                     <td class="ez-table__cell">{{ 'ibexa.stability'|trans|desc('Stability') }}</td>
                     <td class="ez-table__cell">{{ info.stability }}</td>
                 </tr>
@@ -50,6 +42,51 @@
                         </td>
                     </tr>
                 {% endif %}
+            </tbody>
+        </table>
+    </div>
+</section>
+
+<section class="ez-fieldgroup">
+    <h2 class="ez-fieldgroup__name">{{ 'ibexa.subscription'|trans|desc('Subscription') }}</h2>
+    <div class="ez-fieldgroup__content">
+        <table class="table ez-table ez-table--list ez-table--to-left">
+            <tbody>
+            {% if info.subscriptionExpiryDate is not empty %}
+                <tr class="ez-table__row">
+                    <td class="ez-table__cell">{{ 'ibexa.is_trial'|trans|desc('Is Trial') }}</td>
+                    <td class="ez-table__cell">
+                        <svg class="ez-icon ez-icon--small">
+                            <use xlink:href="{{ ez_icon_path(info.isTrial ? 'checkmark' : 'discard') }}"></use>
+                        </svg>
+                    </td>
+                </tr>
+                <tr class="ez-table__row">
+                    <td class="ez-table__cell">{{ 'ibexa.subscription_expiry'|trans|desc('Subscription renewal date') }}*</td>
+                    <td class="ez-table__cell">
+                        {{ info.subscriptionExpiryDate|date('F Y') }}
+                    </td>
+                </tr>
+                <tr class="ez-table__row">
+                    <td colspan="2">
+                        <hr/>
+                        * {{ 'ibexa.subscription_read_more'|trans|desc('Subscription renewal date does not reflect auto renawal, and typically does not represent when the subscription ends') }}
+                    </td>
+                </tr>
+            {% elseif info.shouldHaveSubscription %}
+                <tr class="ez-table__row">
+                    <td class="ez-table__cell ez-alert__content">
+                        {{ 'ibexa.subscription_info_missing'|trans|desc('Subscription info was missing on installation, run the following command to syncronize it') }}
+                        <code>composer run ibexa:sync-subscription</code>
+                    </td>
+                </tr>
+            {% else %}
+                <tr class="ez-table__row">
+                    <td class="ez-table__cell">
+                        {{ 'ibexa.no_subscription'|trans|desc('This install is currently running on Open Source version, which does not come with any subscription') }}
+                    </td>
+                </tr>
+            {% endif %}
             </tbody>
         </table>
     </div>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
@@ -34,8 +34,8 @@
             <div class="ez-alert__content">
                 {{ 'dashboard.ez_version.subscription_missing'|trans({'%command%': 'composer run ibexa:sync-subscription','%file%': 'vendor/ibexa/subscription.json'})
                 |desc("The system could not find your <code>%file%</code> file.
-                For Ibexa DXP installs this is needed to determin access to features and give you feedback if something is not right.
-                Please run <code>%command%</code> to syncronize this info from our updates.ibexa.co servers.")
+                For Ibexa DXP installations this is needed to determine access to features and give you feedback if something is not working correctly.
+                Please run <code>%command%</code> to synchronize this info from our updates.ibexa.co servers.")
                 |raw }}
             </div>
         </div>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
@@ -25,7 +25,21 @@
                 |raw }}
             </div>
         </div>
-    {% elseif ez.stability != 'stable'  %}
+    {% elseif ez.subscriptionExpiryDate is empty and ez.shouldHaveSubscription %}
+        {% set severity = 1 %}
+        <div class="alert alert-warning mb-0 mt-3 ez-alert ez-alert--icon" role="alert">
+            <svg class="ez-icon ez-icon--small-medium ez-icon--light">
+                <use xlink:href="{{ ez_icon_path('system-information') }}"></use>
+            </svg>
+            <div class="ez-alert__content">
+                {{ 'dashboard.ez_version.subscription_missing'|trans({'%command%': 'composer run ibexa:sync-subscription','%file%': 'vendor/ibexa/subscription.json'})
+                |desc("The system could not find your <code>%file%</code> file.
+                For Ibexa DXP installs this is needed to determin access to features and give you feedback if something is not right.
+                Please run <code>%command%</code> to syncronize this info from our updates.ibexa.co servers.")
+                |raw }}
+            </div>
+        </div>
+    {% elseif ez.lowestStability != 'stable'  %}
         {% set severity = 1 %}
         {% set badge = 'Development' %}
         <div class="alert alert-warning mb-0 mt-3 ez-alert ez-alert--icon" role="alert">
@@ -36,7 +50,7 @@
                 {% if ez.composerInfo.minimumStability != 'stable' %}
                     {{ 'dashboard.ez_version.unstable_minimum_stability'|trans({'%minimum_stability%': ez.composerInfo.minimumStability})|desc("Your setup is running with '%minimum_stability%' as composer.json minimum-stability. This is not recommended except when testing updates or during development.") }}
                 {% else  %}
-                    {{ 'dashboard.ez_version.non_stable_packages'|trans({'%stability%': ez.stability})|desc("Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.") }}
+                    {{ 'dashboard.ez_version.non_stable_packages'|trans({'%stability%': ez.lowestStability})|desc("Your setup is running with @%stability% composer packages. This is not recommended except when testing updates or during development.") }}
                 {% endif %}
                 {% if ez.isEnterprise %}
                     {{ 'dashboard.ez_version.non_stable_ee'|trans({'%support_url%': urls['support']})|desc("If you need assistance, don't hesitate to <a target=\"_blank\" href=\"%support_url%\">get in touch with Ibexa support</a>.")|raw }}
@@ -45,7 +59,7 @@
         </div>
     {% elseif ez.isTrial %}
         {% set badge = 'Trial' %}
-        {% if ez.isEndOfLife %}
+        {% if ez.subscriptionExpiryDate < date() %}
             {% set severity = 2 %}
             <div class="alert alert-danger mb-0 mt-3 ez-alert ez-alert--icon" role="alert">
                 <svg class="ez-icon ez-icon--small-medium ez-icon--light">
@@ -53,7 +67,7 @@
                 </svg>
                 <div class="ez-alert__content">
                     {{ 'dashboard.ez_version.trial_expired'|trans({'%ttl_url%': urls['ttl']})|desc("Unfortunately your trial period has expired and your <a target=\"_blank\" href=\"%ttl_url%\">TTL license</a> is no longer valid.")|raw }}
-        {% elseif ez.isEndOfMaintenance %}
+        {% elseif ez.subscriptionExpiryDate < date('-60days') %}
             {% set severity = 1 %}
             <div class="alert alert-warning mb-0 mt-3 ez-alert ez-alert--icon" role="alert">
                 <svg class="ez-icon ez-icon--small-medium ez-icon--light">
@@ -131,8 +145,7 @@
             </div>
         {% endif %}
     {% elseif ez.isEndOfLife %}
-        {# As we don't yet here know if subscription has expired (todo with info from updates.ez.no), this is a warning and not a error #}
-        {% set severity = 1 %}
+        {% set severity = 2 %}
         {% set badge = 'End of Life' %}
         <div class="alert alert-warning mb-0 mt-3 ez-alert ez-alert--icon" role="alert">
             <svg class="ez-icon ez-icon--small-medium ez-icon--light">

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -213,7 +213,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
             $this->composerInfo,
             array_merge(self::ENTERPRISE_PACKAGES, self::COMMERCE_PACKAGES)
         );
-        $ibexa->stability = self::getStability($this->composerInfo);
+        $ibexa->stability = $ibexa->lowestStability = self::getStability($this->composerInfo);
     }
 
     /**

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -152,7 +152,6 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     private function setSubscriptionInfo(IbexaSystemInfo $ibexa): void
     {
         if (!file_exists($this->subscriptionFile)) {
-            //$subscriptionExpiryDate = null;
             return;
         }
 

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -175,6 +175,9 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     private function setSubscriptionInfo(IbexaSystemInfo $ibexa): void
     {
         if (!file_exists($this->subscriptionFile)) {
+            $vendor = sprintf('%s/vendor/', $this->kernelProjectDir);
+            $ibexa->name = EzSystemsEzSupportToolsExtension::getNameByPackages($vendor);
+
             return;
         }
 

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -8,7 +8,6 @@ namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
 
 use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException;
-use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerPackage;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\IbexaSystemInfo;
 use DateTime;
@@ -166,7 +165,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
 
         foreach ($subscriptionData['product_additions'] as $product) {
             // If some of the products is a trial, then currently mark whole install as trial
-            $ibexa->isTrial = $ibexa->isTrial  || $product['trial'];
+            $ibexa->isTrial = $ibexa->isTrial || $product['trial'];
 
             // Map older subscription names to new where needed.
             $identifier = in_array($product['name'], ['enterprise', 'platform']) ? 'experience' : $product['name'];

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
 
 use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
+use EzSystems\EzSupportToolsBundle\DependencyInjection\EzSystemsEzSupportToolsExtension;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\IbexaSystemInfo;
@@ -82,15 +83,24 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     /**
      * Packages that identify installation as "Content".
      */
-    const CONTENT_PACKAGES = [
-        'ezsystems/flex-workflow',
+    public const CONTENT_PACKAGES = [
+        'ezsystems/ezplatform-workflow',
+    ];
+
+    public const EXPERIENCE_PACKAGES = [
+        'ezsystems/ezplatform-page-builder',
+        'ezsystems/landing-page-fieldtype-bundle',
     ];
 
     /**
-     * Packages that identify installation as "Experience".
+     * Packages that identify installation as "Enterprise".
+     *
+     * @deprecated since Ibexa DXP 3.3. Rely either on <code>IbexaSystemInfoCollector::EXPERIENCE_PACKAGES</code>
+     * or <code>IbexaSystemInfoCollector::CONTENT_PACKAGES</code>.
      */
     const ENTERPRISE_PACKAGES = [
         'ezsystems/ezplatform-page-builder',
+        'ezsystems/flex-workflow',
         'ezsystems/landing-page-fieldtype-bundle',
     ];
 
@@ -117,13 +127,20 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
      */
     private $debug;
 
+    /** @var string */
+    private $kernelProjectDir;
+
     /**
      * @param \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector|\EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector $composerCollector
      * @param bool $debug
      * @param string $subscriptionFile = 'vendor/ibexa/subscription.json'
      */
-    public function __construct(SystemInfoCollector $composerCollector, $debug = false, $subscriptionFile = 'vendor/ibexa/subscription.json')
-    {
+    public function __construct(
+        SystemInfoCollector $composerCollector,
+        $kernelProjectDir,
+        $debug = false,
+        $subscriptionFile = 'vendor/ibexa/subscription.json'
+    ) {
         try {
             $this->composerInfo = $composerCollector->collect();
         } catch (ComposerLockFileNotFoundException $e) {
@@ -132,6 +149,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
 
         $this->subscriptionFile = $subscriptionFile;
         $this->debug = $debug;
+        $this->kernelProjectDir = $kernelProjectDir;
     }
 
     /**

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -80,11 +80,17 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     const PACKAGE_WATCH_REGEX = '/^(doctrine|ezsystems|silversolutions|symfony)\//';
 
     /**
-     * Packages that identify installation as "Enterprise".
+     * Packages that identify installation as "Content".
+     */
+    const CONTENT_PACKAGES = [
+        'ezsystems/flex-workflow',
+    ];
+
+    /**
+     * Packages that identify installation as "Experience".
      */
     const ENTERPRISE_PACKAGES = [
         'ezsystems/ezplatform-page-builder',
-        'ezsystems/flex-workflow',
         'ezsystems/landing-page-fieldtype-bundle',
     ];
 
@@ -170,7 +176,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
             // Map older subscription names to new where needed.
             $identifier = in_array($product['name'], ['enterprise', 'platform']) ? 'experience' : $product['name'];
 
-            // Detect product name using subscription info product idenfiter
+            // Detect product name using subscription info product identifier
             if (!$ibexa->isCommerce && $identifier !== 'content') {
                 $ibexa->name = IbexaSystemInfo::PRODUCT_NAME_VARIANTS[$identifier];
 

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -76,18 +76,6 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
     public $endOfLifeDate;
 
     /**
-     * @var bool
-     */
-    public $isTrial = false;
-
-    /**
-     * Lowest stability found in install (packages / minimumStability).
-     *
-     * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
-     */
-    public $lowestStability;
-
-    /**
      * @var \DateTime|null Empty if no subscripton info is found.
      */
     public $subscriptionExpiryDate;
@@ -101,6 +89,18 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
      * @var array List of products that are part of subscription.
      */
     public $subscriptionProducts = [];
+
+    /**
+     * @var bool
+     */
+    public $isTrial = false;
+
+    /**
+     * Lowest stability found in install (packages / minimumStability).
+     *
+     * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
+     */
+    public $lowestStability;
 
     /**
      * @deprecated Instead use $lowestStability.

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -73,17 +73,41 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
     public $isTrial = false;
 
     /**
+     * Lowest stability found in install (packages / minimumStability)
+     * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
+     */
+    public $lowestStability;
+
+    /**
+     * @var \DateTime|null Empty if no subscripton info is found.
+     */
+    public $subscriptionExpiryDate;
+
+    /**
+     * @var bool If install should have subscription data (due to enterpise packages), but it's not present.
+     */
+    public $shouldHaveSubscription;
+
+    /**
+     * @var array List of products that are part of subscription.
+     */
+    public $subscriptionProducts = [];
+
+    /**
+     * @deprecated Instead use $lowestStability.
      * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
      */
     public $stability;
 
     /**
+     * @deprecated Duplicates collected info on symfony
      * @var bool
      */
     public $debug;
 
     /**
-     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo|null
+     * @deprecated This was duplication of collected info from Composer, now only contains key 'minimumStability'
+     * @var array|null
      */
     public $composerInfo;
 }

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -49,24 +49,28 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
 
     /**
      * @var bool
+     *
      * @uses $endOfMaintenanceDate
      */
     public $isEndOfMaintenance = true;
 
     /**
      * @var \DateTime EOM for the given release, if you have an Ibexa DXP / Enterpise susbscription.
+     *
      * @see https://support.ibexa.co/Public/Service-Life
      */
     public $endOfMaintenanceDate;
 
     /**
      * @var bool
+     *
      * @uses $endOfLifeDate
      */
     public $isEndOfLife = true;
 
     /**
      * @var \DateTime EOL for the given release, if you have an Ibexa DXP susbscription.
+     *
      * @see https://support.ibexa.co/Public/Service-Life
      */
     public $endOfLifeDate;
@@ -77,7 +81,8 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
     public $isTrial = false;
 
     /**
-     * Lowest stability found in install (packages / minimumStability)
+     * Lowest stability found in install (packages / minimumStability).
+     *
      * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
      */
     public $lowestStability;
@@ -99,18 +104,21 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
 
     /**
      * @deprecated Instead use $lowestStability.
+     *
      * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
      */
     public $stability;
 
     /**
      * @deprecated Duplicates collected info on symfony
+     *
      * @var bool
      */
     public $debug;
 
     /**
      * @deprecated This was duplication of collected info from Composer, now only contains key 'minimumStability'
+     *
      * @var array|null
      */
     public $composerInfo;

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -49,21 +49,25 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
 
     /**
      * @var bool
+     * @uses $endOfMaintenanceDate
      */
     public $isEndOfMaintenance = true;
 
     /**
-     * @var \DateTime
+     * @var \DateTime EOM for the given release, if you have an Ibexa DXP / Enterpise susbscription.
+     * @see https://support.ibexa.co/Public/Service-Life
      */
     public $endOfMaintenanceDate;
 
     /**
      * @var bool
+     * @uses $endOfLifeDate
      */
     public $isEndOfLife = true;
 
     /**
-     * @var \DateTime
+     * @var \DateTime EOL for the given release, if you have an Ibexa DXP susbscription.
+     * @see https://support.ibexa.co/Public/Service-Life
      */
     public $endOfLifeDate;
 

--- a/src/lib/Composer/SubscriptionPlugin.php
+++ b/src/lib/Composer/SubscriptionPlugin.php
@@ -72,13 +72,14 @@ class SubscriptionPlugin implements PluginInterface, EventSubscriberInterface
 
         $hasUpdatesIbexaCoRepo = false;
         foreach ($this->composer->getRepositoryManager()->getRepositories() as $repo) {
-            if (strpos($repo->getRepoName(), 'https://updates.ibexa.co') !== false) {
+            $url = $repo->getRepoConfig()['url'] ?? null;
+            if (strpos($url, 'https://updates.ibexa.co') !== false) {
                 $hasUpdatesIbexaCoRepo = true;
             }
 
-            if (strpos($repo->getRepoName(), 'https://updates.ez.no/') !== false) {
+            if (strpos($url, 'https://updates.ez.no/') !== false) {
                 $this->writeWarning("WARNING: 'updates.ez.no' is deprecated, for how to use 'updates.ibexa.co' see: https://TODO");
-            } else if (1 === preg_match('@https://updates.ibexa.co/[^/]+@', $repo->getRepoName())) {
+            } else if (1 === preg_match('@^https://updates.ibexa.co/[^/]+@', $url)) {
                 $this->writeWarning("WARNING: Ibexa update repository should be configured as 'https://updates.ibexa.co'");
             }
         }

--- a/src/lib/Composer/SubscriptionPlugin.php
+++ b/src/lib/Composer/SubscriptionPlugin.php
@@ -67,7 +67,6 @@ class SubscriptionPlugin implements PluginInterface, EventSubscriberInterface
 
             // Custom command in order to document what people should run if subscriptin info is missing
             self::DOWNLOAD_SUBSCRIPTION_CMD => 'downloadSubscriptionInfo',
-
         ];
     }
 
@@ -87,7 +86,7 @@ class SubscriptionPlugin implements PluginInterface, EventSubscriberInterface
 
             if (strpos($url, 'https://updates.ez.no/') !== false) {
                 $this->io->write("<warning>'updates.ez.no' is deprecated, for how to use 'updates.ibexa.co' see: https://TODO</>");
-            } else if (1 === preg_match('@^https://updates.ibexa.co/[^/]+@', $url)) {
+            } elseif (1 === preg_match('@^https://updates.ibexa.co/[^/]+@', $url)) {
                 $this->io->write("<warning>Ibexa update repository should be configured as 'https://updates.ibexa.co'</>");
             }
         }
@@ -102,9 +101,8 @@ class SubscriptionPlugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
-
         $this->io->write(
-            "<info>Syncronizing subscription info from: https://updates.ibexa.co/subscription</>",
+            '<info>Syncronizing subscription info from: https://updates.ibexa.co/subscription</>',
             true,
             // If directly called make sure there is some output to console
             $event->getName() === self::DOWNLOAD_SUBSCRIPTION_CMD ? IOInterface::NORMAL : IOInterface::VERBOSE

--- a/src/lib/Composer/SubscriptionPlugin.php
+++ b/src/lib/Composer/SubscriptionPlugin.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzSupportTools\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+use Composer\Plugin\PostFileDownloadEvent;
+use Composer\Plugin\PreFileDownloadEvent;
+
+/**
+ * Class SubscriptionPlugin
+ *
+ * COMPOSER_DEBUG_EVENTS=1 composer update
+ */
+class SubscriptionPlugin implements PluginInterface
+{
+    protected $composer;
+    /**
+     * @var IOInterface
+     */
+    protected $io;
+
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $this->composer = $composer;
+        $this->io = $io;
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            PluginEvents::PRE_FILE_DOWNLOAD => [
+                ['onPreFileDownload', 0],
+            ],
+            // NOTE: Won't be fired if there are no downloads
+            PluginEvents::POST_FILE_DOWNLOAD => [
+                ['onPostFileDownload', 0],
+            ],
+        );
+    }
+
+    public function onPreFileDownload(PreFileDownloadEvent $event)
+    {
+        $url = $event->getProcessedUrl();
+        if (false !== preg_match('@^https://updates.ez.no/[^/]+/packages.json$@', $url)) {
+            $this->io->warning(
+                "updates.ez.no will be sunset by end of 2021, please move to updates.ibexa.co.\n".
+                "    See: blog post url"
+            );
+            return;
+        }
+
+        $this->io->warning(
+            "Match failed"
+        );
+    }
+
+    public function onPostFileDownload(PostFileDownloadEvent $event)
+    {
+        echo $event->getUrl();
+
+        if ($protocol === 's3') {
+            // ...
+        }
+    }
+}

--- a/src/lib/Composer/SubscriptionPlugin.php
+++ b/src/lib/Composer/SubscriptionPlugin.php
@@ -9,23 +9,34 @@ declare(strict_types=1);
 namespace EzSystems\EzSupportTools\Composer;
 
 use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\Plugin\PostFileDownloadEvent;
-use Composer\Plugin\PreFileDownloadEvent;
+use Composer\Script\ScriptEvents;
 
 /**
- * Class SubscriptionPlugin
+ * Plugin for loading subscriction info for hints in admin UI, for trail & expiry info when relevant.
  *
- * COMPOSER_DEBUG_EVENTS=1 composer update
+ * Will only register itself if it detects that install is configerd with 'https://updates.ibexa.co' as composer repository.
+ *
+ * To debug events fired by Composer, use: COMPOSER_DEBUG_EVENTS=1 composer update
  */
-class SubscriptionPlugin implements PluginInterface
+class SubscriptionPlugin implements PluginInterface, EventSubscriberInterface
 {
+    /**
+     * @var Composer
+     */
     protected $composer;
+
     /**
      * @var IOInterface
      */
     protected $io;
+
+    /**
+     * @var bool
+     */
+    private $hasUpdatesIbexaCoRepo = false;
 
     public function activate(Composer $composer, IOInterface $io)
     {
@@ -43,39 +54,57 @@ class SubscriptionPlugin implements PluginInterface
 
     public static function getSubscribedEvents()
     {
-        return array(
-            PluginEvents::PRE_FILE_DOWNLOAD => [
-                ['onPreFileDownload', 0],
-            ],
-            // NOTE: Won't be fired if there are no downloads
-            PluginEvents::POST_FILE_DOWNLOAD => [
-                ['onPostFileDownload', 0],
-            ],
-        );
+        return [
+            ScriptEvents::PRE_INSTALL_CMD => 'checkRepositoryConfig',
+            ScriptEvents::PRE_UPDATE_CMD => 'checkRepositoryConfig',
+
+            ScriptEvents::POST_INSTALL_CMD => 'downloadSubscriptionInfo',
+            ScriptEvents::POST_UPDATE_CMD => 'downloadSubscriptionInfo',
+        ];
     }
 
-    public function onPreFileDownload(PreFileDownloadEvent $event)
+    public function checkRepositoryConfig(): void
     {
-        $url = $event->getProcessedUrl();
-        if (false !== preg_match('@^https://updates.ez.no/[^/]+/packages.json$@', $url)) {
-            $this->io->warning(
-                "updates.ez.no will be sunset by end of 2021, please move to updates.ibexa.co.\n".
-                "    See: blog post url"
-            );
+        foreach ($this->composer->getRepositoryManager()->getRepositories() as $repo) {
+            if (strpos($repo->getRepoName(), 'https://updates.ibexa.co') !== false) {
+                $this->hasUpdatesIbexaCoRepo = true;
+            }
+
+            if (strpos($repo->getRepoName(), 'https://updates.ez.no/') !== false) {
+                $this->writeWarning("WARNING: 'updates.ez.no' is deprecated, for how to use 'updates.ibexa.co' see: https://TODO");
+            } else if (1 === preg_match('@https://updates.ibexa.co/[^/]+@', $repo->getRepoName())) {
+                $this->writeWarning("WARNING: Ibexa update repository should be configured as 'https://updates.ibexa.co'");
+            }
+        }
+    }
+
+    public function downloadSubscriptionInfo(): void
+    {
+        // Skip if we don't have updates.ibexa.co repo yet, as we then probably also don't have AUTH config for it
+        if (!$this->hasUpdatesIbexaCoRepo) {
             return;
         }
 
-        $this->io->warning(
-            "Match failed"
+        !is_dir('vendor/ibexa') && mkdir('vendor/ibexa');
+
+        $this->composer->getLoop()->getHttpDownloader()->addCopy(
+            'https://updates.ibexa.co/subscription',
+            'vendor/ibexa/subscription.json'
+        );
+
+        $this->io->write(
+            "Downloading subscription info from 'https://updates.ibexa.co/subscription'",
+            true,
+            IOInterface::VERBOSE
         );
     }
 
-    public function onPostFileDownload(PostFileDownloadEvent $event)
+    private function writeWarning(string $message)
     {
-        echo $event->getUrl();
-
-        if ($protocol === 's3') {
-            // ...
+        if (method_exists($this->io, 'warning')) {
+            $this->io->warning($message);
+        } else {
+            $this->io->write($message);
         }
     }
 }


### PR DESCRIPTION
Adds a Composer plugin in order to finally be able to get proper subscription info:
- Subscription expiry => _especially significant for Trials, and a must for 3.3 as there isn't any longer such info in license info_
- Products, in order to state product name based on subscription
    - _Example in the future: Be able to give hints if people have not installed certain packages_

**NOTES**:
- _By design this only works if install is using updates.ibexa.co, but that should not be an issue for 3.3 where that is anyway a requirement._
- ~_This is written with compatibility with Composer 1.x, as it only took a few extra lines, and in order to be able to backport this to 2.5 later if Support ever see the need for that._~ _(skipped this in later amendment as 3.3 anyway require Composer 2.0)_

**TODO**:
- [X] Code
- [x] Testing on command line with composer 1.x and 2.x
- [ ] Testing in admin UI and powered by header _(I don't have a fully working setup ATM on new machine)_
- [ ] Add translation strings
- [ ] Optionally: More unit tests coverage

**IMPORTANT NOTE**: ⚠️ 
- [Lukasz/*] Build scripts (for tarballs) for partner portal and support portal will need to be adjusted to delete `vendor/ibexa/subscription.json` at end of build
    - Alternatively remove option for full install (tarballs) and only offer install over Composer / flex
- [QA/DOC] Clean install, and normal composer install should be tested _(Platform.sh and otherwise)_, to see if plugin runs on install / create-project. **Or** if separate `composer update / run post-update-cm / run ibexa:sync-subscription` call needs to be done after project has been created