### PR TITLE
EC-333: Based Commerce detection on ezcommerce-transaction package

### DIFF
--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -108,8 +108,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
      * Packages that identify installation as "Commerce".
      */
     public const COMMERCE_PACKAGES = [
-        'ezsystems/ezcommerce-admin-ui',
-        'silversolutions/silver.e-shop',
+        'ezsystems/ezcommerce-transaction',
     ];
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EC-333](https://issues.ibexa.co/browse/EC-333)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes
| **Doc needed**                       | no

As of today `ezcommerce-admin-ui` is also a part of Ibexa Content, so we need to align with that here and detect Commerce edition based on `ezcommerce-transaction` package.