### PR TITLE
EZP-32307: Fixed check version stability

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -68,11 +68,17 @@ services:
         tags:
             - { name: "support_tools.system_info.collector", identifier: "ibexa" }
 
+    EzSystems\EzSupportTools\VersionStability\ComposerVersionStabilityChecker: ~
+
+    EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker:
+        '@EzSystems\EzSupportTools\VersionStability\ComposerVersionStabilityChecker'
+
     support_tools.system_info.collector.composer.lock_file:
         class: "%support_tools.system_info.collector.composer.lock_file.class%"
         arguments:
-            - "%kernel.project_dir%/composer.lock"
-            - "%kernel.project_dir%/composer.json"
+            $versionStabilityChecker: '@EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker'
+            $lockFile: "%kernel.project_dir%/composer.lock"
+            $jsonFile: "%kernel.project_dir%/composer.json"
         tags:
             - { name: "support_tools.system_info.collector", identifier: "composer" }
 

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
 
 use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
+use EzSystems\EzSupportTools\Value\Stability;
 use EzSystems\EzSupportToolsBundle\DependencyInjection\EzSystemsEzSupportToolsExtension;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo;
@@ -226,7 +227,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
 
     private static function getStability(ComposerSystemInfo $composerInfo): string
     {
-        $stabilityFlags = array_flip(JsonComposerLockSystemInfoCollector::STABILITIES);
+        $stabilityFlags = array_flip(Stability::STABILITIES);
 
         // Root package stability
         $stabilityFlag = $composerInfo->minimumStability !== null ?
@@ -248,7 +249,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
             }
         }
 
-        return JsonComposerLockSystemInfoCollector::STABILITIES[$stabilityFlag];
+        return Stability::STABILITIES[$stabilityFlag];
     }
 
     private static function hasAnyPackage(

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -83,14 +83,14 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
     /**
      * Lowest stability found in the installation (packages / minimumStability).
      *
-     * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
+     * @var string One of {@see \EzSystems\EzSupportTools\Value\Stability::STABILITIES}.
      */
     public $lowestStability;
 
     /**
      * @deprecated Instead use $lowestStability.
      *
-     * @var string One of {@see \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::STABILITIES}.
+     * @var string One of {@see \EzSystems\EzSupportTools\Value\Stability::STABILITIES}.
      */
     public $stability;
 

--- a/src/bundle/Tests/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
+++ b/src/bundle/Tests/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector;
 
 use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
+use EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\IbexaSystemInfoCollector;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\IbexaSystemInfo;
@@ -16,10 +17,20 @@ use PHPUnit\Framework\TestCase;
 
 class IbexaSystemInfoCollectorTest extends TestCase
 {
+    /** @var \EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker|\PHPUnit\Framework\MockObject\MockObject */
+    private $versionStabilityChecker;
+
+    public function setUp(): void
+    {
+        $this->versionStabilityChecker = $this->createMock(VersionStabilityChecker::class);
+    }
+
     public function testCollect(): void
     {
         $composerCollector = new JsonComposerLockSystemInfoCollector(
-            __DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/composer.json'
+            $this->versionStabilityChecker,
+            __DIR__ . '/_fixtures/composer.lock',
+            __DIR__ . '/_fixtures/composer.json'
         );
 
         $systemInfoCollector = new IbexaSystemInfoCollector(

--- a/src/bundle/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/src/bundle/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector;
 
+use EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerJsonFileNotFoundException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException;
@@ -15,10 +16,18 @@ use PHPUnit\Framework\TestCase;
 
 class JsonComposerLockSystemInfoCollectorTest extends TestCase
 {
+    /** @var \EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker|\PHPUnit\Framework\MockObject\MockObject */
+    private $versionStabilityChecker;
+
+    public function setUp(): void
+    {
+        $this->versionStabilityChecker = $this->createMock(VersionStabilityChecker::class);
+    }
+
     /**
      * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
      */
-    public function testCollect()
+    public function testCollectWithMinimumStability()
     {
         $expected = new ComposerSystemInfo([
             'packages' => [
@@ -68,7 +77,11 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
             'repositoryUrls' => ['https://updates.ez.no/bul'],
         ]);
 
-        $composerCollector = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/composer.json');
+        $composerCollector = new JsonComposerLockSystemInfoCollector(
+            $this->versionStabilityChecker,
+            __DIR__ . '/_fixtures/composer.lock',
+            __DIR__ . '/_fixtures/composer.json'
+        );
         $value = $composerCollector->collect();
 
         self::assertInstanceOf('EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo', $value);
@@ -82,7 +95,11 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     {
         $this->expectException(ComposerLockFileNotFoundException::class);
 
-        $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/snafu.lock', __DIR__ . '/_fixtures/composer.json');
+        $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(
+            $this->versionStabilityChecker,
+            __DIR__ . '/_fixtures/snafu.lock',
+            __DIR__ . '/_fixtures/composer.json'
+        );
         $composerCollectorNotFound->collect();
     }
 
@@ -93,7 +110,11 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     {
         $this->expectException(ComposerJsonFileNotFoundException::class);
 
-        $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/snafu.json');
+        $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(
+            $this->versionStabilityChecker,
+            __DIR__ . '/_fixtures/composer.lock',
+            __DIR__ . '/_fixtures/snafu.json'
+        );
         $composerCollectorNotFound->collect();
     }
 }

--- a/src/lib/Tests/VersionStability/VersionStabilityCheckerTest.php
+++ b/src/lib/Tests/VersionStability/VersionStabilityCheckerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzSupportTools\VersionStability;
+
+use EzSystems\EzSupportTools\Value\Stability;
+use PHPUnit\Framework\TestCase;
+
+final class VersionStabilityCheckerTest extends TestCase
+{
+    /** @var \EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker */
+    private $versionStabilityChecker;
+
+    public function setUp(): void
+    {
+        $this->versionStabilityChecker = new ComposerVersionStabilityChecker();
+    }
+
+    /**
+     * @dataProvider provideStableVersions
+     */
+    public function testIsStableVersion(string $stableVersion): void
+    {
+        self::assertTrue(
+            $this->versionStabilityChecker->isStableVersion($stableVersion)
+        );
+    }
+
+    public function provideStableVersions(): iterable
+    {
+        yield ['1.0.0.0'];
+        yield ['1.1.0.0'];
+        yield ['2.10.5.0'];
+        yield ['6.1.10.10'];
+        yield ['15.20.100.1500'];
+    }
+
+    /**
+     * @dataProvider provideNotStableVersions
+     */
+    public function testIsNotStableVersion(string $notStableVersion): void
+    {
+        self::assertFalse(
+            $this->versionStabilityChecker->isStableVersion($notStableVersion)
+        );
+    }
+
+    public function provideNotStableVersions(): iterable
+    {
+        yield ['1.0.20'];
+        yield ['1.0.2-beta'];
+        yield ['1.0.2-beta1'];
+        yield ['1.0.2-rc'];
+        yield ['1.0.2-dev'];
+        yield ['dev-1.0.2'];
+        yield ['dev-master'];
+        yield ['dev-main'];
+        yield ['1.0.2.1-alpha'];
+        yield ['1.0'];
+        yield ['v1.0-rc2'];
+    }
+
+    /**
+     * @dataProvider provideVersions
+     */
+    public function testGetStability(
+        string $version,
+        string $expectedStability
+    ): void {
+        self::assertEquals(
+            $expectedStability,
+            $this->versionStabilityChecker->getStability($version)
+        );
+    }
+
+    public function provideVersions(): iterable
+    {
+        yield ['0.1.10.50', Stability::STABILITIES[0]];
+        yield ['10.10.10.50', Stability::STABILITIES[0]];
+        yield ['1.0.0.1-RC20', Stability::STABILITIES[5]];
+        yield ['1.0.1.5-RC2', Stability::STABILITIES[5]];
+        yield ['1.0.1.5-beta1', Stability::STABILITIES[10]];
+        yield ['1.0.1.5-beta12', Stability::STABILITIES[10]];
+        yield ['1.0.1.5-beta100', Stability::STABILITIES[10]];
+        yield ['1.1000.1.5-beta1000', Stability::STABILITIES[10]];
+        yield ['1.100.10.0-alpha1', Stability::STABILITIES[15]];
+        yield ['1.0.0-alpha5', Stability::STABILITIES[15]];
+        yield ['1.0.0-alpha51', Stability::STABILITIES[15]];
+        yield ['10.10.10.50-dev', Stability::STABILITIES[20]];
+        yield ['dev-master', Stability::STABILITIES[20]];
+        yield ['1.0.0.1-custom', Stability::STABILITIES[20]];
+        yield ['dev-master', Stability::STABILITIES[20]];
+        yield ['dev-test-v1', Stability::STABILITIES[20]];
+        yield ['dev-test_custom', Stability::STABILITIES[20]];
+    }
+}

--- a/src/lib/Value/Stability.php
+++ b/src/lib/Value/Stability.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzSupportTools\Value;
+
+final class Stability
+{
+    /**
+     * @var array Hash of stability constant values to human readable stabilities, see Composer\Package\BasePackage.
+     *
+     * Needed as long as we don't want to depend on Composer.
+     */
+    public const STABILITIES = [
+        0 => 'stable',
+        5 => 'RC',
+        10 => 'beta',
+        15 => 'alpha',
+        20 => 'dev',
+    ];
+}

--- a/src/lib/VersionStability/ComposerVersionStabilityChecker.php
+++ b/src/lib/VersionStability/ComposerVersionStabilityChecker.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzSupportTools\VersionStability;
+
+use EzSystems\EzSupportTools\Value\Stability;
+
+/**
+ * @internal
+ */
+final class ComposerVersionStabilityChecker implements VersionStabilityChecker
+{
+    public function getStability(string $version): string
+    {
+        if ($this->isStableVersion($version)) {
+            return Stability::STABILITIES[0];
+        }
+
+        $stability = $this->getStabilityFromVersionString($version);
+
+        return in_array($stability, Stability::STABILITIES, true)
+            ? $stability
+            : Stability::STABILITIES[20];
+    }
+
+    public function isStableVersion(string $version): bool
+    {
+        $pattern = '/^(\d+\.\d+\.\d+\.\d+)$/';
+
+        return (bool) preg_match($pattern, $version);
+    }
+
+    private function getStabilityFromVersionString(string $version): ?string
+    {
+        return preg_match('/^(dev)-/', $version, $matches)
+        || preg_match('/-(\w+)\d+$/U', $version, $matches)
+            ? $matches[1]
+            : null;
+    }
+}

--- a/src/lib/VersionStability/VersionStabilityChecker.php
+++ b/src/lib/VersionStability/VersionStabilityChecker.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzSupportTools\VersionStability;
+
+interface VersionStabilityChecker
+{
+    public function getStability(string $version): string;
+
+    public function isStableVersion(string $version): bool;
+}


### PR DESCRIPTION
https://issues.ibexa.co/browse/EZP-32307

This PR provides implemented `VersionStabilityChecker` for displaying valid version stability. Since `Ibexa/website-skeleton` (https://github.com/ibexa/website-skeleton/blob/main/composer.json#L6) provides `minimum-stability` set to `dev` all versions are marked as ‘`dev`’. Now version stability is based on `ibexa/oss` version because this package is installed for all Ibexa Platform versions. For BC break reason old check based on composer.lock minimum stability is set as callback in case when Ibexa/oss is not found. 