### PR TITLE
EZP-32348: Exposed services used within the project

### DIFF
--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -26,3 +26,7 @@ parameters:
                 template: '@@ezdesign/system_info/symfony_kernel.html.twig'
                 match:
                     SystemInfo\Identifier: 'symfony_kernel'
+            services:
+                template: '@@ezdesign/system_info/services.html.twig'
+                match:
+                    SystemInfo\Identifier: 'services'

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -14,7 +14,6 @@ parameters:
     support_tools.system_info.collector.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
     support_tools.system_info.collector.php.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector
     support_tools.system_info.collector.symfony.kernel.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollector
-    support_tools.system_info.collector.services.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ServicesSystemInfoCollector
     support_tools.system_info.output_format.json.class: EzSystems\EzSupportToolsBundle\SystemInfo\OutputFormat\JsonOutputFormat
     ezplatform_support_tools.system_info.powered_by.name: ''
     ibexa.system_info.ibexa_url_list:
@@ -113,8 +112,7 @@ services:
         tags:
             - { name: "support_tools.system_info.collector", identifier: "symfony_kernel" }
 
-    support_tools.system_info.collector.services.config:
-        class: "%support_tools.system_info.collector.services.config.class%"
+    EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ServicesSystemInfoCollector:
         arguments:
             - '@parameter_bag'
         tags:

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -14,6 +14,7 @@ parameters:
     support_tools.system_info.collector.hardware.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector
     support_tools.system_info.collector.php.ezc.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector
     support_tools.system_info.collector.symfony.kernel.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollector
+    support_tools.system_info.collector.services.config.class: EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ServicesSystemInfoCollector
     support_tools.system_info.output_format.json.class: EzSystems\EzSupportToolsBundle\SystemInfo\OutputFormat\JsonOutputFormat
     ezplatform_support_tools.system_info.powered_by.name: ''
     ibexa.system_info.ibexa_url_list:
@@ -111,6 +112,13 @@ services:
             - "%kernel.bundles%"
         tags:
             - { name: "support_tools.system_info.collector", identifier: "symfony_kernel" }
+
+    support_tools.system_info.collector.services.config:
+        class: "%support_tools.system_info.collector.services.config.class%"
+        arguments:
+            - '@parameter_bag'
+        tags:
+            - { name: "support_tools.system_info.collector", identifier: "services" }
 
     # SystemInfoOutputFormats
     support_tools.system_info.output_format.json:

--- a/src/bundle/Resources/translations/systeminfo.en.xliff
+++ b/src/bundle/Resources/translations/systeminfo.en.xliff
@@ -176,6 +176,26 @@
         <target state="new">Versions count</target>
         <note>key: repository.versions_count</note>
       </trans-unit>
+      <trans-unit id="3e7aaa79601ad9b577f333a67d082c3752b7e357" resname="services">
+        <source>Services</source>
+        <target state="new">Services</target>
+        <note>key: services</note>
+      </trans-unit>
+      <trans-unit id="9bc1a12ff71e39bc34441abb3dddb60f26a1d9c4" resname="services.http_cache_proxy">
+        <source>HTTP cache proxy</source>
+        <target state="new">HTTP cache proxy</target>
+        <note>key: services.http_cache_proxy</note>
+      </trans-unit>
+      <trans-unit id="f005b719a442f81e3bcf0dfdca767e26c134f1d8" resname="services.persistence_cache_adapter">
+        <source>Persistence cache adapter</source>
+        <target state="new">Persistence cache adapter</target>
+        <note>key: services.persistence_cache_adapter</note>
+      </trans-unit>
+      <trans-unit id="e2a6a37636c55d88afbbc0e16414b31ec456b0ae" resname="services.search_engine">
+        <source>Search engine</source>
+        <target state="new">Search engine</target>
+        <note>key: services.search_engine</note>
+      </trans-unit>
       <trans-unit id="98c89e1daa8c0a7c472af26752752299ff44ee23" resname="symfony_kernel">
         <source>Symfony Kernel</source>
         <target state="new">Symfony Kernel</target>
@@ -270,6 +290,11 @@
         <source>Repository</source>
         <target state="new">Repository</target>
         <note>key: tab.name.repository</note>
+      </trans-unit>
+      <trans-unit id="89ee4f613b63015aec82ada871cd895463340db0" resname="tab.name.services">
+        <source>Services</source>
+        <target state="new">Services</target>
+        <note>key: tab.name.services</note>
       </trans-unit>
       <trans-unit id="b7989598c01fcae061f7917e563a9c0d66790a84" resname="tab.name.symfony_kernel">
         <source>Symfony Kernel</source>

--- a/src/bundle/Resources/views/themes/admin/system_info/services.html.twig
+++ b/src/bundle/Resources/views/themes/admin/system_info/services.html.twig
@@ -1,0 +1,31 @@
+{% trans_default_domain "systeminfo" %}
+
+<!-- Tab name: {{ 'tab.name.services'|trans|desc('Services') }} -->
+
+<section class="ez-fieldgroup">
+    <h2 class="ez-fieldgroup__name">{{ 'services'|trans|desc('Services') }}</h2>
+    <div class="ez-fieldgroup__content">
+        <table class="table ez-table--list">
+            <tbody>
+            <tr class="ez-table__row">
+                <td class="ez-table__cell">
+                    {{ 'services.search_engine'|trans|desc('Search engine') }}
+                </td>
+                <td class="ez-table__cell">{{ info.searchEngine }}</td>
+            </tr>
+            <tr class="ez-table__row">
+                <td class="ez-table__cell">
+                    {{ 'services.http_cache_proxy'|trans|desc('HTTP cache proxy') }}
+                </td>
+                <td class="ez-table__cell">{{ info.httpCacheProxy }}</td>
+            </tr>
+            <tr class="ez-table__row">
+                <td class="ez-table__cell">
+                    {{ 'services.persistence_cache_adapter'|trans|desc('Persistence cache adapter') }}
+                </td>
+                <td class="ez-table__cell">{{ info.persistenceCacheAdapter }}</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/src/bundle/SystemInfo/Collector/ServicesSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/ServicesSystemInfoCollector.php
@@ -28,8 +28,6 @@ class ServicesSystemInfoCollector implements SystemInfoCollector
 
     /**
      * Collects information about the utilized services.
-     *
-     * @return \EzSystems\EzSupportToolsBundle\SystemInfo\Value\ServicesSystemInfo
      */
     public function collect(): ServicesSystemInfo
     {

--- a/src/bundle/SystemInfo/Collector/ServicesSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/ServicesSystemInfoCollector.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
+
+use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ServicesSystemInfo;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * Collects information about the services used within the project.
+ */
+class ServicesSystemInfoCollector implements SystemInfoCollector
+{
+    private const SEARCH_ENGINE_CONFIG_KEY = 'search_engine';
+    private const HTTP_CACHE_CONFIG_KEY = 'purge_type';
+    private const PERSISTENCE_CACHE_CONFIG_KEY = 'cache_pool';
+
+    /** @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface */
+    private $parameterBag;
+
+    public function __construct(ParameterBagInterface $parameterBag)
+    {
+        $this->parameterBag = $parameterBag;
+    }
+
+    /**
+     * Collects information about the utilized services.
+     *
+     * @return \EzSystems\EzSupportToolsBundle\SystemInfo\Value\ServicesSystemInfo
+     */
+    public function collect(): ServicesSystemInfo
+    {
+        return new ServicesSystemInfo([
+            'searchEngine' => $this->parameterBag->get(self::SEARCH_ENGINE_CONFIG_KEY),
+            'httpCacheProxy' => $this->parameterBag->get(self::HTTP_CACHE_CONFIG_KEY),
+            'persistenceCacheAdapter' => $this->parameterBag->get(self::PERSISTENCE_CACHE_CONFIG_KEY),
+        ]);
+    }
+}

--- a/src/bundle/SystemInfo/Value/ServicesSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/ServicesSystemInfo.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Value;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Value for information about services used within the project.
+ */
+class ServicesSystemInfo extends ValueObject implements SystemInfo
+{
+    /**
+     * Search engine.
+     *
+     * Example: Solr
+     *
+     * @var string
+     */
+    public $searchEngine;
+
+    /**
+     * Reverse proxy handling HTTP caching.
+     *
+     * Example: Fastly
+     *
+     * @var string
+     */
+    public $httpCacheProxy;
+
+    /**
+     * Persistence cache adapter.
+     *
+     * Example: Redis
+     *
+     * @var string
+     */
+    public $persistenceCacheAdapter;
+}

--- a/src/bundle/Tests/SystemInfo/Collector/ServicesSystemInfoCollectorTest.php
+++ b/src/bundle/Tests/SystemInfo/Collector/ServicesSystemInfoCollectorTest.php
@@ -19,7 +19,7 @@ class ServicesSystemInfoCollectorTest extends TestCase
     private $parameterBagMock;
 
     /**
-     * @var ServicesSystemInfoCollector
+     * @var \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ServicesSystemInfoCollector
      */
     private $servicesCollector;
 

--- a/src/bundle/Tests/SystemInfo/Collector/ServicesSystemInfoCollectorTest.php
+++ b/src/bundle/Tests/SystemInfo/Collector/ServicesSystemInfoCollectorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector;
+
+use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ServicesSystemInfoCollector;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ServicesSystemInfo;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ServicesSystemInfoCollectorTest extends TestCase
+{
+    /**
+     * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $parameterBagMock;
+
+    /**
+     * @var ServicesSystemInfoCollector
+     */
+    private $servicesCollector;
+
+    protected function setUp(): void
+    {
+        $this->parameterBagMock = $this->createMock(ParameterBagInterface::class);
+        $this->servicesCollector = new ServicesSystemInfoCollector($this->parameterBagMock);
+    }
+
+    /**
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\RepositorySystemInfoCollector::collect()
+     */
+    public function testCollect()
+    {
+        $expected = new ServicesSystemInfo([
+            'searchEngine' => 'solr',
+            'httpCacheProxy' => 'varnish',
+            'persistenceCacheAdapter' => 'cache.adapter.memcached',
+        ]);
+
+        $this->parameterBagMock
+            ->expects($this->at(0))
+            ->method('get')
+            ->willReturn($expected->searchEngine);
+
+        $this->parameterBagMock
+            ->expects($this->at(1))
+            ->method('get')
+            ->willReturn($expected->httpCacheProxy);
+
+        $this->parameterBagMock
+            ->expects($this->at(2))
+            ->method('get')
+            ->willReturn($expected->persistenceCacheAdapter);
+
+        $value = $this->servicesCollector->collect();
+
+        self::assertInstanceOf(ServicesSystemInfo::class, $value);
+        self::assertEquals($expected, $value);
+    }
+}


### PR DESCRIPTION
JIRA ticket: https://issues.ibexa.co/browse/EZP-32348

> The idea is to add another tab containing information about currently used services:
> - search engine,
> - HTTP cache reverse proxy,
> - persistence cache adapter.
>
> To be expanded further in the next steps, more ideas can be found in https://github.com/ezsystems/support-site/issues/108.

<img width="864" alt="Zrzut ekranu 2021-02-17 o 13 15 27" src="https://user-images.githubusercontent.com/34310128/108203001-35c71b80-7122-11eb-9861-e28efe1edc62.png">
