### PR TITLE
IBX-385: Fixed error handling when composer files are corrupted

### DIFF
--- a/Resources/translations/dashboard.en.xlf
+++ b/Resources/translations/dashboard.en.xlf
@@ -73,9 +73,9 @@
         <note>key: dashboard.ez_version.non_stable_ee</note>
       </trans-unit>
       <trans-unit id="c1fb5ba9fd547e30a49a4e1895822e69cd4a9dbc" resname="dashboard.ez_version.release_not_determined">
-        <source><![CDATA[The system could not find your <code>composer.lock</code> file. It's needed to determine information about
+        <source><![CDATA[The system could not find your <code>composer.lock</code> or <code>composer.json</code> file or it's not valid. It's needed to determine information about
             your eZ install, and recommended to be kept on project development to make sure same package versions are used across all environments.]]></source>
-        <target state="new"><![CDATA[The system could not find your <code>composer.lock</code> file. It's needed to determine information about
+        <target state="new"><![CDATA[The system could not find your <code>composer.lock</code> or <code>composer.json</code> file or it's not valid. It's needed to determine information about
             your eZ install, and recommended to be kept on project development to make sure same package versions are used across all environments.]]></target>
         <note>key: dashboard.ez_version.release_not_determined</note>
       </trans-unit>

--- a/Resources/views/themes/admin/dashboard/block/ez.html.twig
+++ b/Resources/views/themes/admin/dashboard/block/ez.html.twig
@@ -16,7 +16,7 @@
         {% set severity = 1 %}
         <div class="alert alert-warning mb-0 mt-3" role="alert">
             {{ 'dashboard.ez_version.release_not_determined'|trans
-            |desc("The system could not find your <code>composer.lock</code> file. It's needed to determine information about
+            |desc("The system could not find your <code>composer.lock</code> or <code>composer.json</code> file or it's not valid. It's needed to determine information about
                 your eZ installation. It is recommended to keep it during project development to make sure the same package versions are
                 used across all environments.")
             |raw }}

--- a/SystemInfo/Collector/EzSystemInfoCollector.php
+++ b/SystemInfo/Collector/EzSystemInfoCollector.php
@@ -8,6 +8,7 @@
  */
 namespace EzSystems\EzSupportToolsBundle\SystemInfo\Collector;
 
+use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerFileValidationException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\EzSystemInfo;
 use DateTime;
@@ -123,7 +124,7 @@ class EzSystemInfoCollector implements SystemInfoCollector
     {
         try {
             $this->composerInfo = $composerCollector->collect();
-        } catch (ComposerLockFileNotFoundException $e) {
+        } catch (ComposerLockFileNotFoundException | ComposerFileValidationException $e) {
             // do nothing
         }
         $this->debug = $debug;

--- a/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
+++ b/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
@@ -54,6 +54,7 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
      * Collects information about installed composer packages.
      *
      * @throws Exception\ComposerLockFileNotFoundException if the composer.lock file was not found.
+     * @throws Exception\ComposerFileValidationException if composer.lock of composer.json are not valid.
      *
      * @return Value\ComposerSystemInfo
      */
@@ -73,6 +74,14 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
 
         $lockData = json_decode(file_get_contents($this->lockFile), true);
         $jsonData = json_decode(file_get_contents($this->jsonFile), true);
+
+        if (!$lockData) {
+            throw new Exception\ComposerFileValidationException($this->lockFile);
+        }
+
+        if (!$jsonData) {
+            throw new Exception\ComposerFileValidationException($this->jsonFile);
+        }
 
         return $this->value = new Value\ComposerSystemInfo([
             'packages' => $this->extractPackages($lockData),

--- a/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
+++ b/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
@@ -75,11 +75,11 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
         $lockData = json_decode(file_get_contents($this->lockFile), true);
         $jsonData = json_decode(file_get_contents($this->jsonFile), true);
 
-        if (!$lockData) {
+        if (!is_array($lockData)) {
             throw new Exception\ComposerFileValidationException($this->lockFile);
         }
 
-        if (!$jsonData) {
+        if (!is_array($jsonData)) {
             throw new Exception\ComposerFileValidationException($this->jsonFile);
         }
 

--- a/SystemInfo/Exception/ComposerFileValidationException.php
+++ b/SystemInfo/Exception/ComposerFileValidationException.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the ComposerJsonFileNotFoundException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -10,7 +8,7 @@ namespace EzSystems\EzSupportToolsBundle\SystemInfo\Exception;
 
 use Exception;
 
-class ComposerFileValidationException extends Exception
+final class ComposerFileValidationException extends Exception implements SystemInfoException
 {
     public function __construct(string $path, $code = 0, Exception $previous = null)
     {

--- a/SystemInfo/Exception/ComposerFileValidationException.php
+++ b/SystemInfo/Exception/ComposerFileValidationException.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * File containing the ComposerJsonFileNotFoundException class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Exception;
+
+use Exception;
+
+class ComposerFileValidationException extends Exception
+{
+    public function __construct(string $path, $code = 0, Exception $previous = null)
+    {
+        $message = sprintf('Composer file %s is not valid.', $path);
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
+++ b/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzSupportToolsBundle\SystemInfo\Exception;
 use Exception;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException as BaseNotFoundException;
 
-class ComposerJsonFileNotFoundException extends BaseNotFoundException
+class ComposerJsonFileNotFoundException extends BaseNotFoundException implements SystemInfoException
 {
     public function __construct(string $path, Exception $previous = null)
     {

--- a/SystemInfo/Exception/ComposerLockFileNotFoundException.php
+++ b/SystemInfo/Exception/ComposerLockFileNotFoundException.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzSupportToolsBundle\SystemInfo\Exception;
 use Exception;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException as BaseNotFoundException;
 
-class ComposerLockFileNotFoundException extends BaseNotFoundException
+class ComposerLockFileNotFoundException extends BaseNotFoundException implements SystemInfoException
 {
     public function __construct($path, Exception $previous = null)
     {

--- a/SystemInfo/Exception/SystemInfoException.php
+++ b/SystemInfo/Exception/SystemInfoException.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Exception;
+
+interface SystemInfoException
+{
+
+}

--- a/SystemInfo/Exception/SystemInfoException.php
+++ b/SystemInfo/Exception/SystemInfoException.php
@@ -8,5 +8,4 @@ namespace EzSystems\EzSupportToolsBundle\SystemInfo\Exception;
 
 interface SystemInfoException
 {
-
 }

--- a/SystemInfo/Value/InvalidSystemInfo.php
+++ b/SystemInfo/Value/InvalidSystemInfo.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the SymfonyKernelSystemInfo class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -13,7 +11,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 /**
  * Invalid value for system info used in case of any errors occur while collecting data.
  */
-class InvalidSystemInfo extends ValueObject implements SystemInfo
+final class InvalidSystemInfo extends ValueObject implements SystemInfo
 {
     /**
      * Error message shown in the System info tab.

--- a/SystemInfo/Value/InvalidSystemInfo.php
+++ b/SystemInfo/Value/InvalidSystemInfo.php
@@ -16,7 +16,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 class InvalidSystemInfo extends ValueObject implements SystemInfo
 {
     /**
-     * Error message shown in the System info tab
+     * Error message shown in the System info tab.
      *
      * @var string
      */

--- a/SystemInfo/Value/InvalidSystemInfo.php
+++ b/SystemInfo/Value/InvalidSystemInfo.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * File containing the SymfonyKernelSystemInfo class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzSupportToolsBundle\SystemInfo\Value;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Invalid value for system info used in case of any errors occur while collecting data.
+ */
+class InvalidSystemInfo extends ValueObject implements SystemInfo
+{
+    /**
+     * Error message shown in the System info tab
+     *
+     * @var string
+     */
+    public $errorMessage;
+}

--- a/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -19,7 +19,7 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     /**
      * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
      */
-    public function testCollect()
+    public function testCollect(): void
     {
         $expected = new ComposerSystemInfo([
             'packages' => [
@@ -81,7 +81,7 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
      *
      * @expectedException \EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException
      */
-    public function testCollectLockFileNotFound()
+    public function testCollectLockFileNotFound(): void
     {
         $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/snafu.lock', __DIR__ . '/_fixtures/composer.json');
         $composerCollectorNotFound->collect();
@@ -92,7 +92,7 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
      *
      * @expectedException \EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerJsonFileNotFoundException
      */
-    public function testCollectJsonFileNotFound()
+    public function testCollectJsonFileNotFound(): void
     {
         $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/snafu.json');
         $composerCollectorNotFound->collect();
@@ -101,7 +101,7 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     /**
      * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
      */
-    public function testCollectLockFileCorrupted()
+    public function testCollectLockFileCorrupted(): void
     {
         $composerCollectorCorrupted = new JsonComposerLockSystemInfoCollector(
             __DIR__ . '/_fixtures/corrupted_composer.lock',
@@ -115,7 +115,7 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     /**
      * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
      */
-    public function testCollectJsonFileCorrupted()
+    public function testCollectJsonFileCorrupted(): void
     {
         $composerCollectorCorrupted = new JsonComposerLockSystemInfoCollector(
             __DIR__ . '/_fixtures/composer.lock',

--- a/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -101,10 +101,24 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     /**
      * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
      */
-    public function testCollectJsonFileCorrupted()
+    public function testCollectLockFileCorrupted()
     {
         $composerCollectorCorrupted = new JsonComposerLockSystemInfoCollector(
             __DIR__ . '/_fixtures/corrupted_composer.lock',
+            __DIR__ . '/_fixtures/composer.json'
+        );
+
+        $this->expectException(ComposerFileValidationException::class);
+        $composerCollectorCorrupted->collect();
+    }
+
+    /**
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
+     */
+    public function testCollectJsonFileCorrupted()
+    {
+        $composerCollectorCorrupted = new JsonComposerLockSystemInfoCollector(
+            __DIR__ . '/_fixtures/composer.lock',
             __DIR__ . '/_fixtures/corrupted_composer.json'
         );
 

--- a/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -9,6 +9,7 @@
 namespace EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector;
 
 use EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerFileValidationException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerPackage;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo;
 use PHPUnit\Framework\TestCase;
@@ -95,5 +96,19 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     {
         $composerCollectorNotFound = new JsonComposerLockSystemInfoCollector(__DIR__ . '/_fixtures/composer.lock', __DIR__ . '/_fixtures/snafu.json');
         $composerCollectorNotFound->collect();
+    }
+
+    /**
+     * @covers \EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector::collect()
+     */
+    public function testCollectJsonFileCorrupted()
+    {
+        $composerCollectorCorrupted = new JsonComposerLockSystemInfoCollector(
+            __DIR__ . '/_fixtures/corrupted_composer.lock',
+            __DIR__ . '/_fixtures/corrupted_composer.json'
+        );
+
+        $this->expectException(ComposerFileValidationException::class);
+        $composerCollectorCorrupted->collect();
     }
 }

--- a/Tests/SystemInfo/Collector/_fixtures/corrupted_composer.json
+++ b/Tests/SystemInfo/Collector/_fixtures/corrupted_composer.json
@@ -1,0 +1,147 @@
+{
+    "name": "ezsystems/ezplatform-ee",,,,,
+    "description": "eZ Platform Enterprise Edition distribution",
+    "homepage": "https://github.com/ezsystems/ezplatform-ee",
+    "license": "proprietary",
+    "type": "project",
+    "authors": [
+        {
+            "name": "eZ dev-team & eZ Community",
+            "homepage": "https://github.com/ezsystems/ezplatform-ee/contributors"
+        }
+    ],
+    "repositories": [
+        { "type": "composer", "url": "https://updates.ez.no/bul" }
+    ],
+    "replace": {
+        "ezsystems/ezstudio": "*",
+        "ezsystems/ezpublish-community": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "AppBundle\\": "src/AppBundle/"
+        },
+        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
+    },
+    "autoload-dev": {
+        "psr-4": { "Tests\\": "tests/" },
+        "files": [ "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
+    },
+    "require": {
+        "php": "^7.1.3",
+        "doctrine/doctrine-bundle": "^1.9.1",
+        "doctrine/orm": "^2.6.3",
+        "ezsystems/date-based-publisher": "^3.2",
+        "ezsystems/doctrine-dbal-schema": "^0.1",
+        "ezsystems/ez-support-tools": "^1.0",
+        "ezsystems/ezplatform-admin-ui": "^1.5",
+        "ezsystems/ezplatform-admin-ui-assets": "^4.1.0",
+        "ezsystems/ezplatform-admin-ui-modules": "^1.5",
+        "ezsystems/ezplatform-core": "^1.0",
+        "ezsystems/ezplatform-cron": "^2.0",
+        "ezsystems/ezplatform-design-engine": "^2.0",
+        "ezsystems/ezplatform-ee-installer": "^2.5",
+        "ezsystems/ezplatform-form-builder": "^1.2",
+        "ezsystems/ezplatform-graphql": "^1.0",
+        "ezsystems/ezplatform-http-cache": "^0.9",
+        "ezsystems/ezplatform-http-cache-fastly": "^1.1",
+        "ezsystems/ezplatform-matrix-fieldtype": "^1.0",
+        "ezsystems/ezplatform-page-builder": "^1.3",
+        "ezsystems/ezplatform-page-fieldtype": "^1.3",
+        "ezsystems/ezplatform-richtext": "^1.1",
+        "ezsystems/ezplatform-solr-search-engine": "^1.6",
+        "ezsystems/ezplatform-standard-design": "^0.2",
+        "ezsystems/ezplatform-user": "^1.0",
+        "ezsystems/ezplatform-workflow": "^1.1",
+        "ezsystems/ezpublish-kernel": "^7.5",
+        "ezsystems/flex-workflow": "^3.2",
+        "ezsystems/repository-forms": "^2.5",
+        "ezsystems/symfony-tools": "~1.0.0",
+        "friendsofsymfony/jsrouting-bundle": "^1.6.3",
+        "gregwar/captcha-bundle": "^2.0",
+        "incenteev/composer-parameter-handler": "^2.1.3",
+        "knplabs/knp-menu-bundle": "^2.2.1",
+        "scssphp/scssphp": "^1.0",
+        "overblog/graphql-bundle": "^0.11.11",
+        "sensio/distribution-bundle": "^5.0.23",
+        "sensiolabs/security-checker": "^5.0",
+        "symfony/assetic-bundle": "^2.8.2",
+        "symfony/monolog-bundle": "^3.3.1",
+        "symfony/swiftmailer-bundle": "^3.2.4",
+        "symfony/symfony": "^3.4.18",
+        "symfony/thanks": "^1.1.0",
+        "symfony/webpack-encore-bundle": "^1.0.0",
+        "twig/extensions": "^1.5.3",
+        "twig/twig": "^2.5",
+        "white-october/pagerfanta-bundle": "^1.2.2",
+        "willdurand/js-translation-bundle": "^2.6.6"
+    },
+    "require-dev": {
+        "behat/behat": "^3.5.0",
+        "behat/mink-extension": "^2.3.1",
+        "behat/mink-goutte-driver": "^1.2.1",
+        "behat/mink-selenium2-driver": "^1.3.1",
+        "behat/symfony2-extension": "^2.1.5",
+        "bex/behat-screenshot": "^1.2.7",
+        "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1.0",
+        "ezsystems/behatbundle": "^6.5.4",
+        "overblog/graphiql-bundle": "^0.1.2",
+        "phpunit/phpunit": "^6.5.13",
+        "sensio/generator-bundle": "^3.1.7",
+        "symfony/phpunit-bridge": "^3.4.18",
+        "liuggio/fastest": "^1.6"
+    },
+    "conflict": {
+        "symfony/symfony": "3.4.9||3.4.12||3.4.16",
+        "doctrine/dbal": "2.7.0",
+        "twig/twig": "2.6.1",
+        "symfony/webpack-encore-bundle": "1.2.0||1.2.1"
+    },
+    "scripts": {
+        "symfony-scripts": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
+            "@php bin/console bazinga:js-translation:dump web/assets --merge-domains",
+            "@php bin/console assetic:dump",
+            "yarn install",
+            "EzSystems\\EzPlatformEncoreBundle\\Composer\\ScriptHandler::compileAssets",
+            "@php bin/security-checker security:check"
+        ],
+        "post-install-cmd": [
+            "@symfony-scripts"
+        ],
+        "post-update-cmd": [
+            "@symfony-scripts"
+        ],
+        "post-create-project-cmd": [
+            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::installWelcomeText"
+        ],
+        "ezplatform-install": [
+            "@php bin/console ezplatform:install ezplatform-ee-clean"
+        ]
+    },
+    "config": {
+        "bin-dir": "bin",
+        "sort-packages": true,
+        "preferred-install": {
+            "ezsystems/*": "dist"
+        }
+    },
+    "extra": {
+        "symfony-app-dir": "app",
+        "symfony-bin-dir": "bin",
+        "symfony-var-dir": "var",
+        "symfony-web-dir": "web",
+        "symfony-tests-dir": "tests",
+        "symfony-assets-install": "relative",
+        "incenteev-parameters": {
+            "keep-outdated": true,
+            "file": "app/config/parameters.yml"
+        },
+        "branch-alias": {
+            "dev-master": "2.5.x-dev"
+        }
+    }
+}

--- a/Tests/SystemInfo/Collector/_fixtures/corrupted_composer.lock
+++ b/Tests/SystemInfo/Collector/_fixtures/corrupted_composer.lock
@@ -1,0 +1,372 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],,,,,
+    "hash": "f154b488295d13aa5c459f0dd8b55d14",
+    "content-hash": "3774c9315d78fd9a89e38cbef1ea6577",
+    "packages": [
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.4,<2.7-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "symfony/console": "2.*"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2016-01-05 22:11:12"
+        },
+        {
+            "name": "ezsystems/ezpublish-kernel",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezsystems/ezpublish-kernel.git",
+                "reference": "ec897baa77c63b745749acf201e85b92bd614723"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezsystems/ezpublish-kernel/zipball/ec897baa77c63b745749acf201e85b92bd614723",
+                "reference": "ec897baa77c63b745749acf201e85b92bd614723",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/doctrine-bundle": "~1.3",
+                "ext-ctype": "*",
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-pdo": "*",
+                "ext-spl": "*",
+                "ext-xsl": "*",
+                "friendsofsymfony/http-cache-bundle": "~1.2",
+                "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
+                "kriswallsmith/buzz": ">=0.9",
+                "liip/imagine-bundle": "~1.0",
+                "nelmio/cors-bundle": "^1.3.3",
+                "ocramius/proxy-manager": "~1.0",
+                "oneup/flysystem-bundle": "~0.4",
+                "pagerfanta/pagerfanta": "~1.0",
+                "php": "~5.5|~7.0",
+                "qafoo/rmf": "1.0.*",
+                "sensio/distribution-bundle": "~3.0",
+                "sensio/framework-extra-bundle": "~3.0",
+                "symfony-cmf/routing": "~1.1",
+                "symfony/symfony": "~2.7",
+                "tedivm/stash-bundle": "0.4.*",
+                "zetacomponents/mail": "~1.8"
+            },
+            "replace": {
+                "ezsystems/ezpublish": "*",
+                "ezsystems/ezpublish-api": "self.version",
+                "ezsystems/ezpublish-spi": "self.version"
+            },
+            "require-dev": {
+                "ezsystems/behatbundle": "^6.1",
+                "matthiasnoback/symfony-dependency-injection-test": "0.*",
+                "mikey179/vfsstream": "1.1.0",
+                "mockery/mockery": "~0.9.4",
+                "phpunit/phpunit": "~4.7.0",
+                "symfony/assetic-bundle": "~2.3"
+            },
+            "suggest": {
+                "php-64bit": "For support of more than 30 languages, a 64bit php installation on all involved prod/dev machines is required"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "EzSystems\\PlatformInstallerBundle\\": "eZ/Bundle/PlatformInstallerBundle/src",
+                    "EzSystems\\PlatformBehatBundle\\": "eZ/Bundle/PlatformBehatBundle"
+                },
+                "psr-0": {
+                    "eZ": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "description": "Kernel used by ezsystems/ezplatform and derivatives. Provides the Content Repository, its APIs, and the application's Symfony framework integration.",
+            "homepage": "http://share.ez.no",
+            "time": "2016-02-28 14:30:53"
+        },
+        {
+            "name": "symfony/symfony",
+            "version": "v2.7.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/symfony.git",
+                "reference": "9a3b6bf6ebee49370aaf15abc1bdeb4b1986a67d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/9a3b6bf6ebee49370aaf15abc1bdeb4b1986a67d",
+                "reference": "9a3b6bf6ebee49370aaf15abc1bdeb4b1986a67d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "~2.4",
+                "paragonie/random_compat": "~1.0",
+                "php": ">=5.3.9",
+                "psr/log": "~1.0",
+                "symfony/polyfill-apcu": "~1.1",
+                "twig/twig": "~1.23|~2.0"
+            },
+            "replace": {
+                "symfony/asset": "self.version",
+                "symfony/browser-kit": "self.version",
+                "symfony/class-loader": "self.version",
+                "symfony/config": "self.version",
+                "symfony/console": "self.version",
+                "symfony/css-selector": "self.version",
+                "symfony/debug": "self.version",
+                "symfony/debug-bundle": "self.version",
+                "symfony/dependency-injection": "self.version",
+                "symfony/doctrine-bridge": "self.version",
+                "symfony/dom-crawler": "self.version",
+                "symfony/event-dispatcher": "self.version",
+                "symfony/expression-language": "self.version",
+                "symfony/filesystem": "self.version",
+                "symfony/finder": "self.version",
+                "symfony/form": "self.version",
+                "symfony/framework-bundle": "self.version",
+                "symfony/http-foundation": "self.version",
+                "symfony/http-kernel": "self.version",
+                "symfony/intl": "self.version",
+                "symfony/locale": "self.version",
+                "symfony/monolog-bridge": "self.version",
+                "symfony/options-resolver": "self.version",
+                "symfony/process": "self.version",
+                "symfony/property-access": "self.version",
+                "symfony/proxy-manager-bridge": "self.version",
+                "symfony/routing": "self.version",
+                "symfony/security": "self.version",
+                "symfony/security-acl": "self.version",
+                "symfony/security-bundle": "self.version",
+                "symfony/security-core": "self.version",
+                "symfony/security-csrf": "self.version",
+                "symfony/security-http": "self.version",
+                "symfony/serializer": "self.version",
+                "symfony/stopwatch": "self.version",
+                "symfony/swiftmailer-bridge": "self.version",
+                "symfony/templating": "self.version",
+                "symfony/translation": "self.version",
+                "symfony/twig-bridge": "self.version",
+                "symfony/twig-bundle": "self.version",
+                "symfony/validator": "self.version",
+                "symfony/var-dumper": "self.version",
+                "symfony/web-profiler-bundle": "self.version",
+                "symfony/yaml": "self.version"
+            },
+            "require-dev": {
+                "doctrine/data-fixtures": "1.0.*",
+                "doctrine/dbal": "~2.4",
+                "doctrine/doctrine-bundle": "~1.2",
+                "doctrine/orm": "~2.4,>=2.4.5",
+                "egulias/email-validator": "~1.2",
+                "ircmaxell/password-compat": "~1.0",
+                "monolog/monolog": "~1.11",
+                "ocramius/proxy-manager": "~0.4|~1.0|~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Doctrine\\": "src/Symfony/Bridge/Doctrine/",
+                    "Symfony\\Bridge\\Monolog\\": "src/Symfony/Bridge/Monolog/",
+                    "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
+                    "Symfony\\Bridge\\Swiftmailer\\": "src/Symfony/Bridge/Swiftmailer/",
+                    "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
+                    "Symfony\\Bundle\\": "src/Symfony/Bundle/",
+                    "Symfony\\Component\\": "src/Symfony/Component/"
+                },
+                "classmap": [
+                    "src/Symfony/Component/HttpFoundation/Resources/stubs",
+                    "src/Symfony/Component/Intl/Resources/stubs"
+                ],
+                "files": [
+                    "src/Symfony/Component/Intl/Resources/stubs/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "The Symfony PHP framework",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "framework"
+            ],
+            "time": "2016-02-28 20:37:19"
+        },
+        {
+            "name": "zetacomponents/system-information",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zetacomponents/SystemInformation.git",
+                "reference": "be0e5b69dde0a51f8d2a036b891964521939769f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zetacomponents/SystemInformation/zipball/be0e5b69dde0a51f8d2a036b891964521939769f",
+                "reference": "be0e5b69dde0a51f8d2a036b891964521939769f",
+                "shasum": ""
+            },
+            "require": {
+                "zetacomponents/base": "~1.8"
+            },
+            "require-dev": {
+                "zetacomponents/unit-test": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sergey Alexeev"
+                },
+                {
+                    "name": "Sebastian Bergmann"
+                },
+                {
+                    "name": "Jan Borsodi"
+                },
+                {
+                    "name": "Raymond Bosman"
+                },
+                {
+                    "name": "Frederik Holljen"
+                },
+                {
+                    "name": "Kore Nordmann"
+                },
+                {
+                    "name": "Derick Rethans"
+                },
+                {
+                    "name": "Vadym Savchuk"
+                },
+                {
+                    "name": "Tobias Schlitt"
+                },
+                {
+                    "name": "Alexandru Stanoi"
+                }
+            ],
+            "description": "Provides access to common system variables, such as CPU type and speed, and the available amount of memory.",
+            "homepage": "https://github.com/zetacomponents",
+            "time": "2014-09-27 19:26:09"
+        }
+    ],
+    "packages-dev": null,
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "ezsystems/ezpublish-kernel": 20,
+        "ezsystems/repository-forms": 20,
+        "ezsystems/ezplatform-solr-search-engine": 20,
+        "ezsystems/platform-ui-bundle": 20,
+        "ezsystems/platform-ui-assets-bundle": 15,
+        "ezsystems/ez-support-tools": 20,
+        "ezsystems/behatbundle": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "~5.5|~7.0"
+    },
+    "platform-dev": []
+}

--- a/View/SystemInfoViewBuilder.php
+++ b/View/SystemInfoViewBuilder.php
@@ -6,6 +6,7 @@ namespace EzSystems\EzSupportToolsBundle\View;
 
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Exception\SystemInfoException;
 use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
 use EzSystems\EzSupportToolsBundle\SystemInfo\Value\InvalidSystemInfo;
 
@@ -41,7 +42,7 @@ class SystemInfoViewBuilder implements ViewBuilder
 
         try {
             $collectedData = $collector->collect();
-        } catch (\Exception $e) {
+        } catch (SystemInfoException $e) {
             $collectedData = new InvalidSystemInfo();
             $collectedData->errorMessage = $e->getMessage();
         }

--- a/View/SystemInfoViewBuilder.php
+++ b/View/SystemInfoViewBuilder.php
@@ -7,6 +7,7 @@ namespace EzSystems\EzSupportToolsBundle\View;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry;
+use EzSystems\EzSupportToolsBundle\SystemInfo\Value\InvalidSystemInfo;
 
 class SystemInfoViewBuilder implements ViewBuilder
 {
@@ -37,8 +38,15 @@ class SystemInfoViewBuilder implements ViewBuilder
     {
         $collector = $this->getCollector($parameters['systemInfoIdentifier']);
         $view = new SystemInfoView(null, [], $parameters['viewType']);
-        $view->setInfo($collector->collect());
 
+        try {
+            $collectedData = $collector->collect();
+        } catch (\Exception $e) {
+            $collectedData = new InvalidSystemInfo();
+            $collectedData->errorMessage = $e->getMessage();
+        }
+
+        $view->setInfo($collectedData);
         $this->viewConfigurator->configure($view);
 
         return $view;

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ocramius/proxy-manager": "~1.0 || ~2.0",
         "symfony/proxy-manager-bridge": "^2.8.40 || ^3.4.11",
         "zetacomponents/system-information": "^1.1.1",
-        "ezsystems/ezplatform-admin-ui": "dev-ibx-385-responsiveness-if-composer-files-corrupted as 1.5.x-dev"
+        "ezsystems/ezplatform-admin-ui": "^1.5@dev"
     },
     "require-dev": {
         "ezsystems/ezplatform-code-style": "^0.1.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ocramius/proxy-manager": "~1.0 || ~2.0",
         "symfony/proxy-manager-bridge": "^2.8.40 || ^3.4.11",
         "zetacomponents/system-information": "^1.1.1",
-        "ezsystems/ezplatform-admin-ui": "^1.5@dev"
+        "ezsystems/ezplatform-admin-ui": "dev-ibx-385-responsiveness-if-composer-files-corrupted as 1.5.x-dev"
     },
     "require-dev": {
         "ezsystems/ezplatform-code-style": "^0.1.0",


### PR DESCRIPTION
JIRA ticket: [IBX-385](https://issues.ibexa.co/browse/IBX-385)

>Currently, whenever composer.json or composer.lock files get accidentally corrupted, the system will return exceptions coming from ez-support-tools (where those files are parsed) which results in the system being unusable. The idea is to show some warnings in:
>- the dashboard,
> - the System Information tab,
> - ez-support-tools:dump-info
>if the composer files are either not accessible or don't contain valid data.

Depends on https://github.com/ezsystems/ezplatform-admin-ui/pull/1758.

TODO:
- [x] remove dependency to `ezplatform-admin-ui` PR before merge

//edit not sure to what I owe ezrobot's endorsement... 😄 