### PR TITLE
IBX-385: Fixed tests failing after merge-up

### DIFF
--- a/src/bundle/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/src/bundle/Tests/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -125,6 +125,7 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     public function testCollectLockFileCorrupted(): void
     {
         $composerCollectorCorrupted = new JsonComposerLockSystemInfoCollector(
+            $this->versionStabilityChecker,
             __DIR__ . '/_fixtures/corrupted_composer.lock',
             __DIR__ . '/_fixtures/composer.json'
         );
@@ -139,6 +140,7 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
     public function testCollectJsonFileCorrupted(): void
     {
         $composerCollectorCorrupted = new JsonComposerLockSystemInfoCollector(
+            $this->versionStabilityChecker,
             __DIR__ . '/_fixtures/composer.lock',
             __DIR__ . '/_fixtures/corrupted_composer.json'
         );


### PR DESCRIPTION
The test flaw introduced in: https://github.com/ezsystems/ez-support-tools/commit/d2b375038c586f6cc863587030268248035e8712.