### PR TITLE
EZP-31560: Fixed VersionStabilityCheckerTest class file path

### DIFF
--- a/src/lib/Tests/VersionStability/VersionStabilityCheckerTest.php
+++ b/src/lib/Tests/VersionStability/VersionStabilityCheckerTest.php
@@ -6,9 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzSupportTools\VersionStability;
+namespace EzSystems\EzSupportTools\Tests\VersionStability;
 
 use EzSystems\EzSupportTools\Value\Stability;
+use EzSystems\EzSupportTools\VersionStability\ComposerVersionStabilityChecker;
 use PHPUnit\Framework\TestCase;
 
 final class VersionStabilityCheckerTest extends TestCase


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31560](https://issues.ibexa.co/browse/EZP-31560)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3` - please update `x` accordingly
| **BC breaks**                          | no

Class `EzSystems\EzSupportTools\VersionStability\VersionStabilityCheckerTest` located in `./src/lib/Tests/VersionStability/VersionStabilityCheckerTest.php` does not comply with psr-4 autoloading standard. 

Introduced in #86 and missed by accident.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // na
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).


