### PR TITLE
Fixed Composer license info and bumped license & copyright year

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright (C) 1999-2021 Ibexa AS (formerly eZ Systems AS). All rights reserved.
+Copyright (C) 1999-2024 Ibexa AS (formerly eZ Systems AS). All rights reserved.
 
 This source code is available separately under the following licenses:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 1999-2021 Ibexa AS (formerly eZ Systems AS). All rights reserved.
+Copyright (C) 1999-2024 Ibexa AS (formerly eZ Systems AS). All rights reserved.
 
 This source code is available separately under the following licenses:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ administrators and Support engineers.
 
 ## COPYRIGHT
 
-Copyright (C) 1999-2021 Ibexa AS (formerly eZ Systems AS). All rights reserved.
+Copyright (C) 1999-2024 Ibexa AS (formerly eZ Systems AS). All rights reserved.
 
 ## LICENSE
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ezsystems/ez-support-tools",
     "description": "Providing information about the system eZ Platform/Enterprise/Commerce is running on, and eZ install itself",
-    "license": "GPL-2.0",
+    "license": "(GPL-2.0-only or proprietary)",
     "type": "ezplatform-bundle",
     "authors": [
         {


### PR DESCRIPTION
```
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
# General warnings
- License "GPL-2.0" is a deprecated SPDX license identifier, use "GPL-2.0-only" or "GPL-2.0-or-later" instead
```
We have GPL + BUL type of licensing, therefore updated as it should be.

while at it, I updated year to 2024.